### PR TITLE
fix(flutter): 500-message chat perf acceptance (do not merge to main)

### DIFF
--- a/apps/mobile_flutter/README.md
+++ b/apps/mobile_flutter/README.md
@@ -62,5 +62,14 @@ Android uses the same timing/scale. Haptics are `performHapticFeedback` (CLOCK_T
 ## CI
 
 - Smoke (push to `work/flutter-native` only, plus `workflow_dispatch`): `.github/workflows/flutter-mobile-ci.yml`
+  - `analyze-test` is the performance gate: `flutter test` includes `test/chat_transcript_perf_test.dart` (500-message fixture, rebuild-count + CI CPU budgets).
   - Android job uploads `openchamber-flutter-android-debug-apk-<shortsha>` (14-day retention). The file inside is `openchamber-v2-debug-<shortsha>.apk` (`com.yee94.openchamber.debug`). GitHub login required; the zip is not a public Release.
 - Signed release (`workflow_dispatch`, existing Capacitor secrets): `.github/workflows/flutter-mobile-release.yml`
+- No `integration_test` / `flutter drive` CI job. Linux has no phone GPU; macos-15 only compiles the simulator app. Local Timeline (not claimed 真机过):
+
+```bash
+cd apps/mobile_flutter
+flutter test test/chat_transcript_perf_test.dart
+flutter run --profile -d <device-or-sim>
+# DevTools → Performance → record fling + text-only stream + reasoning toggle
+```

--- a/apps/mobile_flutter/lib/data/chat_markdown_cache.dart
+++ b/apps/mobile_flutter/lib/data/chat_markdown_cache.dart
@@ -19,7 +19,7 @@ class ChatMarkdownBuildCounters {
 class ChatMarkdownSourceCache {
   ChatMarkdownSourceCache._();
 
-  static const int maxEntries = 128;
+  static const int maxEntries = 512;
   static final List<String> _order = [];
   static final Set<String> _keys = {};
 

--- a/apps/mobile_flutter/lib/data/chat_rebuild_counters.dart
+++ b/apps/mobile_flutter/lib/data/chat_rebuild_counters.dart
@@ -1,0 +1,48 @@
+/// Operation counters for chat list / row / reasoning rebuild isolation.
+///
+/// Widget tests assert these. They are not a systrace and do not prove a
+/// mid-range phone GPU path.
+class ChatRebuildCounters {
+  ChatRebuildCounters._();
+
+  static int listStructureBuilds = 0;
+  static int rowWidgetBuilds = 0;
+  static int rowSlotBuilds = 0;
+  static int reasoningBuilds = 0;
+  static final Map<String, int> rowWidgetBuildsById = {};
+  static final Map<String, int> rowSlotBuildsById = {};
+  static final Map<String, int> reasoningBuildsById = {};
+
+  static void reset() {
+    listStructureBuilds = 0;
+    rowWidgetBuilds = 0;
+    rowSlotBuilds = 0;
+    reasoningBuilds = 0;
+    rowWidgetBuildsById.clear();
+    rowSlotBuildsById.clear();
+    reasoningBuildsById.clear();
+  }
+
+  static void recordListStructure() => listStructureBuilds += 1;
+
+  static void recordRowWidget(String id) {
+    rowWidgetBuilds += 1;
+    rowWidgetBuildsById[id] = (rowWidgetBuildsById[id] ?? 0) + 1;
+  }
+
+  static void recordRowSlot(String id) {
+    rowSlotBuilds += 1;
+    rowSlotBuildsById[id] = (rowSlotBuildsById[id] ?? 0) + 1;
+  }
+
+  static void recordReasoning(String id) {
+    reasoningBuilds += 1;
+    reasoningBuildsById[id] = (reasoningBuildsById[id] ?? 0) + 1;
+  }
+
+  static int rowWidgetBuildsFor(String id) => rowWidgetBuildsById[id] ?? 0;
+
+  static int rowSlotBuildsFor(String id) => rowSlotBuildsById[id] ?? 0;
+
+  static int reasoningBuildsFor(String id) => reasoningBuildsById[id] ?? 0;
+}

--- a/apps/mobile_flutter/lib/data/long_context_fixture.dart
+++ b/apps/mobile_flutter/lib/data/long_context_fixture.dart
@@ -2,14 +2,14 @@ import 'chat_timeline.dart';
 
 /// Deterministic long-context transcript for scroll / Markdown stress tests.
 ///
-/// Default: 160 turns (320 messages). Each assistant body is multi-KB GFM
+/// Default: 250 turns (500 messages). Each assistant body is multi-KB GFM
 /// with headings, emphasis, lists, blockquotes, links, and fenced code.
-/// Several turns also carry reasoning + a tool card so mixed rows are real.
+/// Many turns also carry a long collapsed reasoning block + a tool card.
 class LongContextFixture {
   const LongContextFixture._();
 
-  static const int defaultTurns = 160;
-  static const int codeLinesPerAssistant = 80;
+  static const int defaultTurns = 250;
+  static const int codeLinesPerAssistant = 100;
 
   static List<ChatMessage> build({int turns = defaultTurns}) {
     final out = <ChatMessage>[];
@@ -21,7 +21,7 @@ class LongContextFixture {
           isUser: true,
         ),
       );
-      final mixed = i % 5 == 0;
+      final mixed = i % 3 == 0 || i == turns - 1;
       final aborted = i == turns - 3;
       final empty = i == turns - 2;
       out.add(
@@ -88,9 +88,16 @@ class LongContextFixture {
   }
 
   static String reasoningMarkdown(int seed) {
-    return 'First thought about turn $seed and how to approach the long context.\n'
+    final buffer = StringBuffer()
+      ..writeln('First thought about turn $seed and how to approach the long context.')
+      ..writeln(
         'Second line goes deeper so the collapsed header summary truncates '
-        'before this hidden detail $seed.';
+        'before this hidden detail $seed.',
+      );
+    for (var line = 0; line < 12; line += 1) {
+      buffer.writeln('Hidden reasoning paragraph $line for turn $seed — not in the 80-char summary.');
+    }
+    return buffer.toString();
   }
 
   static int estimatedLineCount({int turns = defaultTurns}) {

--- a/apps/mobile_flutter/lib/features/chat/chat_markdown_body.dart
+++ b/apps/mobile_flutter/lib/features/chat/chat_markdown_body.dart
@@ -36,6 +36,9 @@ class ChatMarkdownBody extends StatefulWidget {
 class _ChatMarkdownBodyState extends State<ChatMarkdownBody> {
   late String _committed = widget.text;
   String? _builtIdentity;
+  Widget? _builtBody;
+  MarkdownStyleSheet? _styleSheet;
+  Brightness? _styleBrightness;
   Timer? _pace;
 
   @override
@@ -63,26 +66,36 @@ class _ChatMarkdownBodyState extends State<ChatMarkdownBody> {
     super.dispose();
   }
 
+  MarkdownStyleSheet _sheetFor(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    if (_styleSheet != null && _styleBrightness == brightness) {
+      return _styleSheet!;
+    }
+    _styleBrightness = brightness;
+    _styleSheet = ocMarkdownStyleSheet(context);
+    return _styleSheet!;
+  }
+
   @override
   Widget build(BuildContext context) {
     final source = _committed;
     if (source.trim().isEmpty) return const SizedBox.shrink();
     final identity = '${widget.cacheKey ?? ''}#${source.hashCode}:${Theme.of(context).brightness}';
-    if (_builtIdentity == identity) {
+    if (_builtIdentity == identity && _builtBody != null) {
       ChatMarkdownBuildCounters.reuseHits += 1;
-    } else {
-      ChatMarkdownBuildCounters.builds += 1;
-      ChatMarkdownSourceCache.remember(identity);
-      _builtIdentity = identity;
+      return _builtBody!;
     }
-    return MarkdownBody(
+    ChatMarkdownBuildCounters.builds += 1;
+    ChatMarkdownSourceCache.remember(identity);
+    _builtIdentity = identity;
+    _builtBody = MarkdownBody(
       key: Key('chat-markdown-${widget.cacheKey ?? 'anon'}'),
       data: source,
       shrinkWrap: true,
       fitContent: true,
       softLineBreak: true,
       selectable: false,
-      styleSheet: ocMarkdownStyleSheet(context),
+      styleSheet: _sheetFor(context),
       onTapLink: (text, href, title) {
         final url = href?.trim() ?? '';
         if (url.isEmpty) return;
@@ -90,6 +103,7 @@ class _ChatMarkdownBodyState extends State<ChatMarkdownBody> {
         unawaited(opener.open(url).catchError((Object _) {}));
       },
     );
+    return _builtBody!;
   }
 }
 

--- a/apps/mobile_flutter/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_flutter/lib/features/chat/chat_screen.dart
@@ -340,30 +340,27 @@ class _ChatScreenState extends State<ChatScreen> {
       backgroundColor: context.oc.pageBackground,
       body: Stack(
         children: [
-          ListenableBuilder(
-            listenable: _timeline,
-            builder: (context, _) {
+          ReverseChatList(
+            controller: _timeline,
+            scrollController: _scroll,
+            paddingBuilder: (length) {
               final composerReserve = composerListReserve(
                 ios: ios,
                 viewBottom: view.bottom,
                 insetBottom: inset.bottom,
-                showScrollToBottom: _timeline.length >= 2,
+                showScrollToBottom: length >= 2,
               );
-              return ReverseChatList(
+              return EdgeInsets.fromLTRB(12, navH, 12, composerReserve + 12);
+            },
+            itemBuilder: (context, message, reverseIndex) {
+              return ChatTranscriptRow(
                 controller: _timeline,
-                scrollController: _scroll,
-                padding: EdgeInsets.fromLTRB(12, navH, 12, composerReserve + 12),
-                itemBuilder: (context, message, reverseIndex) {
-                  return ChatTranscriptRow(
-                    controller: _timeline,
-                    messageId: message.id,
-                    reverseIndex: reverseIndex,
-                    busy: _busy,
-                    speakingId: _speakingMessageId,
-                    onSpeak: widget.appController == null ? null : _speak,
-                    onPermission: widget.appController == null ? null : _replyPermission,
-                  );
-                },
+                messageId: message.id,
+                reverseIndex: reverseIndex,
+                busy: _busy,
+                speakingId: _speakingMessageId,
+                onSpeak: widget.appController == null ? null : _speak,
+                onPermission: widget.appController == null ? null : _replyPermission,
               );
             },
           ),

--- a/apps/mobile_flutter/lib/features/chat/chat_transcript_row.dart
+++ b/apps/mobile_flutter/lib/features/chat/chat_transcript_row.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../data/chat_rebuild_counters.dart';
 import '../../data/chat_timeline.dart';
 import '../../data/context_tool_grouping.dart';
 import '../../theme/ios_chrome.dart';
@@ -35,8 +36,10 @@ class ChatTranscriptRow extends StatelessWidget {
         return ListenableBuilder(
           listenable: Listenable.merge([busy, speakingId]),
           builder: (context, _) {
+            ChatRebuildCounters.recordRowSlot(message.id);
             final isLastAssistant = !message.isUser && controller.isNewestAssistant(reverseIndex);
-            final isTurnLive = busy.value && isLastAssistant && messageHasRunningTool(message);
+            final isStreamingAssistant = busy.value && isLastAssistant;
+            final isTurnLive = isStreamingAssistant && messageHasRunningTool(message);
             if (message.isUser) {
               return Align(
                 alignment: Alignment.centerRight,
@@ -57,6 +60,7 @@ class ChatTranscriptRow extends StatelessWidget {
                           message: message,
                           isLastAssistant: isLastAssistant,
                           isTurnLive: isTurnLive,
+                          isStreaming: isStreamingAssistant,
                           isSpeaking: speakingId.value == message.id,
                         ),
                       ),
@@ -73,6 +77,7 @@ class ChatTranscriptRow extends StatelessWidget {
                 message: message,
                 isLastAssistant: isLastAssistant,
                 isTurnLive: isTurnLive,
+                isStreaming: isStreamingAssistant,
                 isSpeaking: speakingId.value == message.id,
                 onSpeak: onSpeak == null ? null : () => onSpeak!(message),
                 onPermission: onPermission,

--- a/apps/mobile_flutter/lib/features/chat/reasoning_block.dart
+++ b/apps/mobile_flutter/lib/features/chat/reasoning_block.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../data/chat_rebuild_counters.dart';
 import '../../data/chat_timeline.dart';
 import '../../l10n/app_strings.dart';
 import '../../motion/oc_motion.dart';
@@ -96,6 +97,7 @@ class _ReasoningTraceBlockState extends State<ReasoningTraceBlock>
 
   @override
   Widget build(BuildContext context) {
+    ChatRebuildCounters.recordReasoning(widget.part.id);
     final text = widget.part.body ?? '';
     if (text.trim().isEmpty) return const SizedBox.shrink();
     final tokens = OcTokens.of(context);

--- a/apps/mobile_flutter/lib/features/chat/reverse_chat_list.dart
+++ b/apps/mobile_flutter/lib/features/chat/reverse_chat_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import '../../data/chat_rebuild_counters.dart';
 import '../../data/chat_timeline.dart';
 
 /// Reverse chat list — LegendList analogue.
@@ -10,7 +11,8 @@ import '../../data/chat_timeline.dart';
 ///
 /// The list rebuilds only when [ReverseChatController] reports a **structure**
 /// change. Streaming tokens update per-id [ValueNotifier] slots and must not
-/// reconstruct this [ListView].
+/// reconstruct this [ListView]. Padding that depends on length is computed
+/// here so [ChatScreen] does not also subscribe to structure notifies.
 class ReverseChatList extends StatelessWidget {
   const ReverseChatList({
     super.key,
@@ -18,23 +20,26 @@ class ReverseChatList extends StatelessWidget {
     required this.itemBuilder,
     this.scrollController,
     this.padding,
+    this.paddingBuilder,
   });
 
   final ReverseChatController controller;
   final Widget Function(BuildContext context, ChatMessage message, int reverseIndex) itemBuilder;
   final ScrollController? scrollController;
   final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry Function(int length)? paddingBuilder;
 
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: controller,
       builder: (context, _) {
+        ChatRebuildCounters.recordListStructure();
         return ListView.builder(
           key: const Key('reverse-chat-list'),
           controller: scrollController,
           reverse: true,
-          padding: padding,
+          padding: paddingBuilder?.call(controller.length) ?? padding,
           addAutomaticKeepAlives: false,
           addRepaintBoundaries: true,
           findChildIndexCallback: (key) {
@@ -46,6 +51,7 @@ class ReverseChatList extends StatelessWidget {
           itemCount: controller.length,
           itemBuilder: (context, index) {
             final message = controller.newestAtReverseIndex(index);
+            ChatRebuildCounters.recordRowWidget(message.id);
             return KeyedSubtree(
               key: ValueKey<String>(message.id),
               child: itemBuilder(context, message, index),

--- a/apps/mobile_flutter/lib/features/chat/tool_cards.dart
+++ b/apps/mobile_flutter/lib/features/chat/tool_cards.dart
@@ -20,6 +20,7 @@ class ChatTranscriptBody extends StatelessWidget {
     this.onSpeak,
     this.isLastAssistant = false,
     this.isTurnLive = false,
+    this.isStreaming = false,
     this.isSpeaking = false,
   });
 
@@ -28,6 +29,9 @@ class ChatTranscriptBody extends StatelessWidget {
   final VoidCallback? onSpeak;
   final bool isLastAssistant;
   final bool isTurnLive;
+  /// Busy last-assistant turn. Independent of a running tool so text-only
+  /// SSE tokens still debounce Markdown and auto-expand live reasoning.
+  final bool isStreaming;
   final bool isSpeaking;
 
   @override
@@ -79,8 +83,9 @@ class ChatTranscriptBody extends StatelessWidget {
         out.add(Padding(
           padding: const EdgeInsets.only(top: 8),
           child: ReasoningTraceBlock(
+            key: ValueKey<String>('reasoning-widget-${part.id}'),
             part: part,
-            isLive: isTurnLive && part.status != 'completed',
+            isLive: isStreaming && part.status != 'completed',
           ),
         ));
       } else if (part.kind == ChatPartKind.text && (part.body ?? '').trim().isNotEmpty) {
@@ -98,7 +103,7 @@ class ChatTranscriptBody extends StatelessWidget {
             ChatMarkdownBody(
               cacheKey: '${message.id}-${part.id}',
               text: part.body!.trim(),
-              isLive: isTurnLive && isLastAssistant,
+              isLive: isStreaming && isLastAssistant,
             ),
           );
           paintedText = true;
@@ -139,7 +144,7 @@ class ChatTranscriptBody extends StatelessWidget {
         ChatMarkdownBody(
           cacheKey: '${message.id}-body',
           text: message.body.trim(),
-          isLive: isTurnLive && isLastAssistant,
+          isLive: isStreaming && isLastAssistant,
         ),
       );
     }

--- a/apps/mobile_flutter/test/chat_markdown_body_test.dart
+++ b/apps/mobile_flutter/test/chat_markdown_body_test.dart
@@ -76,6 +76,23 @@ void main() {}
     expect(find.textContaining('已跑:'), findsWidgets);
   });
 
+  testWidgets('live tokens coalesce to one Markdown commit after 64ms', (tester) async {
+    await tester.pumpWidget(_wrap(const ChatMarkdownBody(cacheKey: 'pace', text: 'Hello', isLive: true)));
+    final builds = ChatMarkdownBuildCounters.builds;
+    expect(builds, greaterThan(0));
+
+    for (var i = 1; i <= 6; i += 1) {
+      await tester.pumpWidget(_wrap(ChatMarkdownBody(cacheKey: 'pace', text: 'Hello${'!' * i}', isLive: true)));
+      await tester.pump();
+    }
+    expect(ChatMarkdownBuildCounters.builds, builds, reason: 'tokens inside the 64ms window must not parse');
+
+    await tester.pump(ChatMarkdownBody.livePace);
+    await tester.pump();
+    expect(ChatMarkdownBuildCounters.builds, builds + 1);
+    expect(find.textContaining('Hello!!!!!!'), findsWidgets);
+  });
+
   testWidgets('identical source rebuilds hit the Markdown cache', (tester) async {
     await tester.pumpWidget(_wrap(const ChatMarkdownBody(cacheKey: 'cache', text: 'Hello **world**')));
     final builds = ChatMarkdownBuildCounters.builds;

--- a/apps/mobile_flutter/test/chat_transcript_perf_test.dart
+++ b/apps/mobile_flutter/test/chat_transcript_perf_test.dart
@@ -1,50 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openchamber/data/chat_markdown_cache.dart';
+import 'package:openchamber/data/chat_rebuild_counters.dart';
 import 'package:openchamber/data/chat_timeline.dart';
 import 'package:openchamber/data/home_session.dart';
 import 'package:openchamber/data/long_context_fixture.dart';
+import 'package:openchamber/features/chat/chat_markdown_body.dart';
 import 'package:openchamber/features/chat/chat_screen.dart';
+import 'package:openchamber/features/chat/chat_transcript_row.dart';
+import 'package:openchamber/features/chat/reverse_chat_list.dart';
 import 'package:openchamber/l10n/app_strings.dart';
+import 'package:openchamber/motion/oc_motion.dart';
 import 'package:openchamber/theme/app_theme.dart';
+
+const _session = HomeSessionRow(
+  id: 'sess-perf',
+  title: 'Long context',
+  projectLabel: 'OpenChamber',
+  kind: HomeSessionKind.catalog,
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('long-context fixture is hundreds of rows and tens of thousands of lines', () {
-    final messages = LongContextFixture.build();
-    expect(messages.length, LongContextFixture.defaultTurns * 2);
-    expect(messages.length, greaterThanOrEqualTo(200));
-    expect(LongContextFixture.estimatedLineCount(), greaterThanOrEqualTo(10000));
-    expect(messages.where((message) => !message.isUser).first.body, contains('```dart'));
-    expect(messages.any((message) => message.parts.any((part) => part.kind == ChatPartKind.reasoning)), isTrue);
+  setUp(() {
+    ChatMarkdownBuildCounters.reset();
+    ChatRebuildCounters.reset();
+    ChatMarkdownSourceCache.clear();
   });
 
-  testWidgets('long transcript scroll stays lazy and Markdown builds stay bounded', (tester) async {
-    ChatMarkdownBuildCounters.reset();
+  test('long-context fixture is 500+ rows with large fences and many reasoning blocks', () {
+    final messages = LongContextFixture.build();
+    expect(messages.length, LongContextFixture.defaultTurns * 2);
+    expect(messages.length, greaterThanOrEqualTo(500));
+    expect(LongContextFixture.estimatedLineCount(), greaterThanOrEqualTo(25000));
+    expect(messages.where((message) => !message.isUser).first.body, contains('```dart'));
+    final reasoning = messages.where((message) => message.parts.any((part) => part.kind == ChatPartKind.reasoning)).length;
+    expect(reasoning, greaterThanOrEqualTo(80));
+    expect(messages.last.parts.any((part) => part.kind == ChatPartKind.reasoning), isTrue);
+    expect(LongContextFixture.reasoningMarkdown(0), contains('Hidden reasoning paragraph'));
+  });
+
+  testWidgets('500-message transcript stays lazy, settles scroll, and bounds first-frame work', (tester) async {
     final fixture = LongContextFixture.build();
     final timeline = ReverseChatController(seed: fixture);
     addTearDown(timeline.dispose);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: materialTheme(Brightness.light),
-        home: StringsScope(
-          strings: AppStrings.of(AppStrings.en),
-          child: ChatScreen(
-            session: const HomeSessionRow(
-              id: 'sess-perf',
-              title: 'Long context',
-              projectLabel: 'OpenChamber',
-              kind: HomeSessionKind.catalog,
-            ),
-            timeline: timeline,
-          ),
-        ),
-      ),
-    );
+    await tester.pumpWidget(_chatApp(ChatScreen(session: _session, timeline: timeline)));
+
+    final mountPump = Stopwatch()..start();
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
+    mountPump.stop();
 
     expect(find.byKey(const Key('reverse-chat-list')), findsOneWidget);
     final afterMount = ChatMarkdownBuildCounters.builds;
@@ -53,11 +61,28 @@ void main() {
       lessThan(40),
       reason: 'ListView.builder must not parse every message on mount (got $afterMount)',
     );
+    expect(
+      mountPump.elapsedMilliseconds,
+      lessThan(2500),
+      reason: 'first frames after 500-message mount took ${mountPump.elapsedMilliseconds}ms (CI CPU budget, not 16ms phone frames)',
+    );
 
     final list = find.byKey(const Key('reverse-chat-list'));
-    await tester.fling(list, const Offset(0, 1200), 2400);
+    final scrollWatch = Stopwatch()..start();
+    await tester.fling(list, const Offset(0, 1800), 3200);
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 16),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 3),
+    );
+    scrollWatch.stop();
+    expect(
+      scrollWatch.elapsedMilliseconds,
+      lessThan(3000),
+      reason: 'fling+settle took ${scrollWatch.elapsedMilliseconds}ms',
+    );
+
     final afterFling = ChatMarkdownBuildCounters.builds;
     expect(afterFling, greaterThanOrEqualTo(afterMount));
     expect(
@@ -74,9 +99,11 @@ void main() {
 
     final beforeReplay = ChatMarkdownBuildCounters.builds;
     final structureBefore = timeline.structureNotifyCount;
+    final listBuildsBefore = ChatRebuildCounters.listStructureBuilds;
     timeline.applyMessages(List<ChatMessage>.from(timeline.oldestFirst));
     await tester.pump();
     expect(timeline.structureNotifyCount, structureBefore);
+    expect(ChatRebuildCounters.listStructureBuilds, listBuildsBefore);
     expect(
       ChatMarkdownBuildCounters.builds,
       beforeReplay,
@@ -94,5 +121,203 @@ void main() {
     ]);
     await tester.pump();
     expect(timeline.structureNotifyCount, structureBefore, reason: 'in-place tail edit is a slot write, not a list rebuild');
+    expect(ChatRebuildCounters.listStructureBuilds, listBuildsBefore);
   }, timeout: const Timeout(Duration(minutes: 2)));
+
+  testWidgets('single-message SSE token does not rebuild the list or the neighbor row', (tester) async {
+    final busy = ValueNotifier(true);
+    final speaking = ValueNotifier<String?>(null);
+    addTearDown(busy.dispose);
+    addTearDown(speaking.dispose);
+
+    final timeline = ReverseChatController(
+      seed: [
+        const ChatMessage(
+          id: 'settled',
+          body: 'Settled **done**.',
+          isUser: false,
+          parts: [
+            ChatPart(id: 'settled-text', kind: ChatPartKind.text, title: 'text', body: 'Settled **done**.'),
+            ChatPart(
+              id: 'settled-think',
+              kind: ChatPartKind.reasoning,
+              title: 'thinking',
+              body: 'First thought about the settled turn.\nHidden settled detail that must stay collapsed.',
+              status: 'completed',
+            ),
+          ],
+        ),
+        const ChatMessage(
+          id: 'live',
+          body: 'Hello',
+          isUser: false,
+          parts: [
+            ChatPart(id: 'live-text', kind: ChatPartKind.text, title: 'text', body: 'Hello'),
+          ],
+        ),
+      ],
+    );
+    addTearDown(timeline.dispose);
+
+    await tester.pumpWidget(_chatApp(_listHarness(timeline: timeline, busy: busy, speaking: speaking)));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('chat-message-settled')), findsOneWidget);
+    expect(find.byKey(const Key('chat-message-live')), findsOneWidget);
+
+    final structureBefore = timeline.structureNotifyCount;
+    final listBefore = ChatRebuildCounters.listStructureBuilds;
+    final settledSlots = ChatRebuildCounters.rowSlotBuildsFor('settled');
+    final settledReasoning = ChatRebuildCounters.reasoningBuildsFor('settled-think');
+    final settledWidgets = ChatRebuildCounters.rowWidgetBuildsFor('settled');
+    final markdownBefore = ChatMarkdownBuildCounters.builds;
+    var liveSlotTicks = 0;
+    timeline.slotFor('live').addListener(() => liveSlotTicks += 1);
+    var settledSlotTicks = 0;
+    timeline.slotFor('settled').addListener(() => settledSlotTicks += 1);
+
+    for (var i = 1; i <= 8; i += 1) {
+      timeline.applyMessages([
+        timeline.oldestFirst.first,
+        ChatMessage(
+          id: 'live',
+          body: 'Hello${'!' * i}',
+          isUser: false,
+          parts: [
+            ChatPart(id: 'live-text', kind: ChatPartKind.text, title: 'text', body: 'Hello${'!' * i}'),
+          ],
+        ),
+      ]);
+      await tester.pump();
+    }
+
+    expect(timeline.structureNotifyCount, structureBefore);
+    expect(ChatRebuildCounters.listStructureBuilds, listBefore);
+    expect(ChatRebuildCounters.rowWidgetBuildsFor('settled'), settledWidgets);
+    expect(ChatRebuildCounters.rowSlotBuildsFor('settled'), settledSlots);
+    expect(ChatRebuildCounters.reasoningBuildsFor('settled-think'), settledReasoning);
+    expect(settledSlotTicks, 0);
+    expect(liveSlotTicks, 8);
+    expect(
+      ChatMarkdownBuildCounters.builds,
+      markdownBefore,
+      reason: 'live 64ms pace must coalesce 8 tokens before the timer fires (got ${ChatMarkdownBuildCounters.builds - markdownBefore} extra builds)',
+    );
+
+    await tester.pump(ChatMarkdownBody.livePace);
+    await tester.pump();
+    expect(ChatMarkdownBuildCounters.builds, markdownBefore + 1);
+    expect(ChatRebuildCounters.rowSlotBuildsFor('settled'), settledSlots);
+    expect(find.textContaining('Hello!!!!!!!!'), findsWidgets);
+  });
+
+  testWidgets('reasoning expand/collapse does not rebuild unrelated rows and still matches official motion', (tester) async {
+    final busy = ValueNotifier(false);
+    final speaking = ValueNotifier<String?>(null);
+    addTearDown(busy.dispose);
+    addTearDown(speaking.dispose);
+
+    final timeline = ReverseChatController(
+      seed: [
+        const ChatMessage(
+          id: 'other',
+          body: 'Neighbor',
+          isUser: false,
+          parts: [
+            ChatPart(id: 'other-text', kind: ChatPartKind.text, title: 'text', body: 'Neighbor **row**'),
+            ChatPart(
+              id: 'other-think',
+              kind: ChatPartKind.reasoning,
+              title: 'thinking',
+              body: 'First thought about the neighbor.\nHidden neighbor detail that must not remount.',
+              status: 'completed',
+            ),
+          ],
+        ),
+        const ChatMessage(
+          id: 'target',
+          body: 'Target',
+          isUser: false,
+          parts: [
+            ChatPart(id: 'target-text', kind: ChatPartKind.text, title: 'text', body: 'Target **row**'),
+            ChatPart(
+              id: 'target-think',
+              kind: ChatPartKind.reasoning,
+              title: 'thinking',
+              body: 'First thought about the target row.\nHidden target detail that mounts only when expanded.',
+              status: 'completed',
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(timeline.dispose);
+
+    await tester.pumpWidget(_chatApp(_listHarness(timeline: timeline, busy: busy, speaking: speaking)));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(MarkdownBody), findsNWidgets(2));
+    expect(find.byKey(const Key('chat-reasoning-summary-target-think')), findsOneWidget);
+
+    final listBefore = ChatRebuildCounters.listStructureBuilds;
+    final otherSlots = ChatRebuildCounters.rowSlotBuildsFor('other');
+    final otherReasoning = ChatRebuildCounters.reasoningBuildsFor('other-think');
+    final otherWidgets = ChatRebuildCounters.rowWidgetBuildsFor('other');
+    final markdownBefore = ChatMarkdownBuildCounters.builds;
+
+    await tester.tap(find.byKey(const Key('chat-reasoning-toggle-target-think')));
+    await tester.pump();
+    await tester.pump(OcMotion.reasoningExpand);
+
+    expect(find.byKey(const Key('chat-markdown-reasoning-target-think')), findsOneWidget);
+    expect(find.textContaining('Hidden target detail'), findsWidgets);
+    expect(ChatRebuildCounters.listStructureBuilds, listBefore);
+    expect(ChatRebuildCounters.rowWidgetBuildsFor('other'), otherWidgets);
+    expect(ChatRebuildCounters.rowSlotBuildsFor('other'), otherSlots);
+    expect(ChatRebuildCounters.reasoningBuildsFor('other-think'), otherReasoning);
+    expect(ChatMarkdownBuildCounters.builds, markdownBefore + 1);
+
+    await tester.tap(find.byKey(const Key('chat-reasoning-toggle-target-think')));
+    await tester.pump();
+    await tester.pump(OcMotion.reasoningExpand);
+    await tester.pump(OcMotion.reasoningUnmountDelay);
+
+    expect(find.byKey(const Key('chat-markdown-reasoning-target-think')), findsNothing);
+    expect(ChatRebuildCounters.listStructureBuilds, listBefore);
+    expect(ChatRebuildCounters.rowSlotBuildsFor('other'), otherSlots);
+    expect(ChatRebuildCounters.reasoningBuildsFor('other-think'), otherReasoning);
+  });
+}
+
+Widget _chatApp(Widget home) {
+  return MaterialApp(
+    theme: materialTheme(Brightness.light),
+    home: StringsScope(
+      strings: AppStrings.of(AppStrings.en),
+      child: home,
+    ),
+  );
+}
+
+Widget _listHarness({
+  required ReverseChatController timeline,
+  required ValueNotifier<bool> busy,
+  required ValueNotifier<String?> speaking,
+}) {
+  return Scaffold(
+    body: ReverseChatList(
+      controller: timeline,
+      itemBuilder: (context, message, reverseIndex) {
+        return ChatTranscriptRow(
+          controller: timeline,
+          messageId: message.id,
+          reverseIndex: reverseIndex,
+          busy: busy,
+          speakingId: speaking,
+        );
+      },
+    ),
+  );
 }

--- a/apps/mobile_flutter/test/chat_transcript_perf_test.dart
+++ b/apps/mobile_flutter/test/chat_transcript_perf_test.dart
@@ -66,6 +66,12 @@ void main() {
       lessThan(2500),
       reason: 'first frames after 500-message mount took ${mountPump.elapsedMilliseconds}ms (CI CPU budget, not 16ms phone frames)',
     );
+    debugPrint(
+      'chat-perf mount: messages=${fixture.length} markdownBuilds=$afterMount '
+      'listBuilds=${ChatRebuildCounters.listStructureBuilds} '
+      'rowWidgets=${ChatRebuildCounters.rowWidgetBuilds} '
+      'ms=${mountPump.elapsedMilliseconds}',
+    );
 
     final list = find.byKey(const Key('reverse-chat-list'));
     final scrollWatch = Stopwatch()..start();
@@ -89,6 +95,9 @@ void main() {
       afterFling,
       lessThan(80),
       reason: 'scroll must hydrate a window, not O(n=${fixture.length}) Markdown trees (got $afterFling)',
+    );
+    debugPrint(
+      'chat-perf fling: markdownBuilds=$afterFling settleMs=${scrollWatch.elapsedMilliseconds}',
     );
 
     final position = tester.widget<ListView>(list).controller!.position;
@@ -210,6 +219,11 @@ void main() {
     expect(ChatMarkdownBuildCounters.builds, markdownBefore + 1);
     expect(ChatRebuildCounters.rowSlotBuildsFor('settled'), settledSlots);
     expect(find.textContaining('Hello!!!!!!!!'), findsWidgets);
+    debugPrint(
+      'chat-perf sse: liveSlotTicks=$liveSlotTicks settledSlotTicks=$settledSlotTicks '
+      'listBuilds=${ChatRebuildCounters.listStructureBuilds - listBefore} '
+      'markdownDelta=${ChatMarkdownBuildCounters.builds - markdownBefore}',
+    );
   });
 
   testWidgets('reasoning expand/collapse does not rebuild unrelated rows and still matches official motion', (tester) async {
@@ -288,6 +302,12 @@ void main() {
     expect(ChatRebuildCounters.listStructureBuilds, listBefore);
     expect(ChatRebuildCounters.rowSlotBuildsFor('other'), otherSlots);
     expect(ChatRebuildCounters.reasoningBuildsFor('other-think'), otherReasoning);
+    debugPrint(
+      'chat-perf reasoning: listDelta=${ChatRebuildCounters.listStructureBuilds - listBefore} '
+      'otherSlotDelta=${ChatRebuildCounters.rowSlotBuildsFor('other') - otherSlots} '
+      'otherReasoningDelta=${ChatRebuildCounters.reasoningBuildsFor('other-think') - otherReasoning} '
+      'markdownDelta=${ChatMarkdownBuildCounters.builds - markdownBefore}',
+    );
   });
 }
 

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -526,26 +526,51 @@ Yee device walk on the v2 debug APK: assistant/user bodies were plain `Text` (on
 |---|---|
 | Markdown package | **`flutter_markdown_plus` ^1.0.7** — maintained successor to discontinued `flutter_markdown`. Newest release that resolves on the CI pin **Flutter 3.32.8 / Dart 3.8.1** (`1.0.12` needs a newer SDK). `MarkdownBody` shrink-wraps inside the reverse list. `gpt_markdown` adds LaTeX/chrome we do not need; `markdown_widget`'s default `MarkdownWidget` is its own scroller (nested scrollables). |
 | Typography | Official mobile `--text-markdown` 15 / `OcOptical.chatBodyHeight` 1.45. Headings stay the same size (official `--markdown-hN-font-size: var(--text-markdown)`), weight 600. Code is `monospace` / `--text-code` 13 on `surfaceSubtle`. Colors from `OcTokens`. |
-| Streaming | Live bodies debounce at official `streamingRenderCadence.markdownPaceMs` **64ms**. Incomplete fences / unclosed emphasis must not throw. |
-| List | Still `ListView.builder(reverse: true)` (LegendList behaviour, not TanStack Virtual). `ReverseChatController` is a `ChangeNotifier` for **structure only** (ids/order/length). Per-message `ValueNotifier` slots update the live tail. `findChildIndexCallback` keeps element identity. `addAutomaticKeepAlives: false`. |
+| Streaming | Live bodies debounce at official `streamingRenderCadence.markdownPaceMs` **64ms**. Incomplete fences / unclosed emphasis must not throw. **`isStreaming` is busy + newest assistant**, not “has a running tool”. Tool-only `isTurnLive` still owns Activity lock-open. |
+| List | Still `ListView.builder(reverse: true)` (LegendList behaviour, not TanStack Virtual). `ReverseChatController` is a `ChangeNotifier` for **structure only** (ids/order/length). Per-message `ValueNotifier` slots update the live tail. `findChildIndexCallback` keeps element identity. `addAutomaticKeepAlives: false`. `ChatScreen` does **not** re-subscribe to structure; padding that depends on length is computed inside `ReverseChatList`. |
 | Stick-to-bottom | Reverse offset `0` is the live edge. Transcript reloads **never** `jumpTo`. Scrolled-up (`offset > 24`) readers stay put when tokens arrive. `chat-scroll-to-bottom` jumps to 0. |
-| Reasoning | Official `type: 'reasoning'` (also `thinking` / `redacted_reasoning`). Default **collapsed** (`ReasoningPart.test.tsx`). Motion from `ReasoningPart.tsx`: height **200ms `easeOut`**, inner fade **180ms `easeOut`**, Markdown **unmounts 200ms** after collapse (`EXPANDED_CONTENT_UNMOUNT_DELAY_MS`). Streaming auto-expands while `time.end` is missing. Header summary is 80 chars, markdown-stripped. |
+| Reasoning | Official `type: 'reasoning'` (also `thinking` / `redacted_reasoning`). Default **collapsed** (`ReasoningPart.test.tsx`). Motion from `ReasoningPart.tsx`: height **200ms `easeOut`**, inner fade **180ms `easeOut`**, Markdown **unmounts 200ms** after collapse (`EXPANDED_CONTENT_UNMOUNT_DELAY_MS`). Streaming auto-expands while `status != completed`. Header summary is 80 chars, markdown-stripped. Collapsed traces do not keep a mounted Markdown tree. |
 
-### Long-context stress test (local)
+### Long-context acceptance (CI)
+
+`Flutter Mobile CI` → `analyze-test` → `flutter test` already runs `test/chat_transcript_perf_test.dart` on Linux (Flutter 3.32.8). That is the performance gate. There is **no** `integration_test` / `flutter drive` job: Linux has no phone GPU, and the macos-15 job only compiles the iOS simulator app. A second simulator-run job would be an unreliable extra 15+ minutes without proving Impeller/Skia jank.
 
 ```bash
 cd apps/mobile_flutter
-flutter test test/chat_transcript_perf_test.dart
+flutter test test/chat_transcript_perf_test.dart test/chat_markdown_body_test.dart test/reasoning_block_test.dart
 ```
 
-Fixture: `LongContextFixture.build()` — **160 turns / 320 messages**, each assistant body is multi-KB GFM (headings, lists, blockquotes, links, 80-line dart fences). Estimated **≥ 10k lines**. The widget test mounts `ChatScreen`, flings + jumps the reverse list, and asserts Markdown `builds` stay in a visible window (`< 40` on mount, `< 80` after fling) and that `applyMessages` of the same ids does not notify structure or rematerialize Markdown.
+Fixture: `LongContextFixture.build()` — **250 turns / 500 messages**, 100-line dart fences, reasoning on every 3rd turn plus the live tail. Estimated **≥ 25k lines**. Assertions:
 
-Related: `flutter test test/chat_markdown_body_test.dart test/reasoning_block_test.dart test/chat_boundary_cases_test.dart`.
+| Gate | Bound |
+|---|---|
+| Mount Markdown parses | `< 40` (viewport window, not O(n)) |
+| First frames after mount | `< 2500ms` wall (CI CPU budget; **not** a 16ms phone frame) |
+| Fling + `pumpAndSettle` | `< 3000ms` wall, Markdown parses `< 80` |
+| Identical `applyMessages` | 0 structure notifies, 0 list rebuilds, 0 extra Markdown parses |
+| 8 SSE tokens on the live tail | 0 list rebuilds, 0 neighbor slot/reasoning rebuilds, **1** Markdown parse after 64ms |
+| Reasoning expand/collapse | neighbor row + neighbor reasoning rebuild counts unchanged; Markdown unmounts after 200ms |
+
+Related: `flutter test test/chat_boundary_cases_test.dart`.
+
+### Local Timeline (not CI — needs a profile device or simulator)
+
+Widget tests do not record Impeller/Skia GPU frames. To take a Timeline on a machine that has a device:
+
+```bash
+cd apps/mobile_flutter
+flutter run --profile -d <device-or-sim>
+# DevTools → Performance → start recording
+# Open a long session, fling the reverse list, watch a text-only stream,
+# expand/collapse a settled reasoning block, then stop.
+```
+
+Budget on a real device: settled scroll should stay near 16ms UI frames; a live Markdown commit at the 64ms pace may spike. That path is **not** claimed 真机过.
 
 ### Remaining known gaps (chat body / list only)
 
 1. No Shiki / syntax colors inside fences (official web uses a worker). Mono + horizontal overflow is the Flutter floor.
 2. Reasoning is a first-class body disclosure (official **live** path). Sorted-mode Activity projection of reasoning rows is not a second copy.
 3. Encrypted/redacted reasoning with empty text stays hidden (same as official empty-text hide). No placeholder “encrypted thinking” chip.
-4. `WidgetTester` scroll counters are not a systrace on a mid-range Android phone. Device jank still needs a v2 APK walk.
+4. `WidgetTester` rebuild counters and CI CPU budgets are not a systrace on a mid-range Android phone. Phone-only residual: Impeller raster, glyph cache, and large-fence decode on a physical GPU.
 5. Pixel/golden chrome (composer glass, dock, goldens) stays on the Flutter UI track. This slice did not recapture `docs/flutter-native-screenshots/*`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Flutter performance acceptance for the chat list + reasoning path. Landed on `work/flutter-native` (`aa92c4d` / `b25f13c`). **Do not merge to main.**

## CI (green)

Flutter Mobile CI **#33827941242** on tip `be683acf0` (includes this patch + later list-ink goldens):

- Flutter analyze and widget tests — success
- Android debug APK — success (`com.yee94.openchamber.debug`)
- iOS simulator build — success

https://github.com/yee94/openchambery/actions/runs/33827941242

## Measured (CI Linux, Flutter 3.32.8)

| Interaction | Number |
|---|---|
| Fixture | **500 messages**, 100-line dart fences, ≥80 reasoning blocks |
| Mount | 1 Markdown parse, 1 list structure build, 1 row widget, **19ms** |
| Fling + settle | **4** Markdown parses total, **472ms** |
| 8 SSE tokens on live tail | 8 live slot ticks, **0** settled, **0** list rebuilds, **1** Markdown parse after 64ms |
| Reasoning expand/collapse | **0** neighbor rebuilds; **+1** Markdown on expand; unmount after 200ms |

## User-visible fix

Live Markdown debounce + reasoning auto-expand now key off **busy + newest assistant**, not “has a running tool”. Text-only SSE was re-parsing every token.

## APK

https://github.com/yee94/openchambery/releases/download/flutter-v2-debug-be683ac/openchamber-v2-debug-be683ac.apk

Prerelease `flutter-v2-debug-be683ac`. Package `com.yee94.openchamber.debug`.

## Residual — not 真机过

Phone-only: Impeller raster, glyph cache, large-fence decode. Rebuild counters do not prove a physical GPU path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5df07d4c-54a5-4a78-abca-fd7e4f5167a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5df07d4c-54a5-4a78-abca-fd7e4f5167a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

