### PR TITLE
test(flutter): harden relay/media acceptance without 真机过

### DIFF
--- a/apps/mobile_flutter/README.md
+++ b/apps/mobile_flutter/README.md
@@ -63,7 +63,7 @@ Android uses the same timing/scale. Haptics are `performHapticFeedback` (CLOCK_T
 
 - Smoke (push to `work/flutter-native` only, plus `workflow_dispatch`): `.github/workflows/flutter-mobile-ci.yml`
   - `analyze-test` is the performance gate: `flutter test` includes `test/chat_transcript_perf_test.dart` (500-message fixture, rebuild-count + CI CPU budgets).
-  - Android job uploads `openchamber-flutter-android-debug-apk-<shortsha>` (14-day retention). The file inside is `openchamber-v2-debug-<shortsha>.apk` (`com.yee94.openchamber.debug`). GitHub login required; the zip is not a public Release.
+  - Android job uploads `openchamber-flutter-android-debug-apk-<shortsha>` (14-day retention). The file inside is `openchamber-v2-debug-<shortsha>.apk` (`com.yee94.openchamber.debug`). Latest sideload prerelease: [`flutter-v2-debug-915c22d`](https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-915c22d).
 - Signed release (`workflow_dispatch`, existing Capacitor secrets): `.github/workflows/flutter-mobile-release.yml`
 - No `integration_test` / `flutter drive` CI job. Linux has no phone GPU; macos-15 only compiles the simulator app. Local Timeline (not claimed 真机过):
 

--- a/apps/mobile_flutter/lib/data/app_controller.dart
+++ b/apps/mobile_flutter/lib/data/app_controller.dart
@@ -53,6 +53,7 @@ class AppController extends ChangeNotifier {
     OpenRelayTunnel? openRelayTunnel,
     ExternalBrowser? browser,
     Duration? relayRaceHeadstart,
+    Future<void> Function(Duration duration)? relayRaceWait,
   })  : _store = store,
         _qrScanner = qrScanner ?? QrScanner(),
         _deepLinks = deepLinks ?? DeepLinkListener(),
@@ -61,7 +62,8 @@ class AppController extends ChangeNotifier {
         browser = browser ?? ExternalBrowser(),
         _instances = seed?.instances ?? const [],
         _activeId = seed?.activeId,
-        relayRaceHeadstart = relayRaceHeadstart ?? const Duration(milliseconds: 1500) {
+        relayRaceHeadstart = relayRaceHeadstart ?? const Duration(milliseconds: 1500),
+        relayRaceWait = relayRaceWait {
     _directTransport = _api.transport;
     _openRelayTunnel = openRelayTunnel ?? _defaultOpenRelay;
     remoteSettings = SettingsRemoteStore(
@@ -85,6 +87,7 @@ class AppController extends ChangeNotifier {
   late final OpenRelayTunnel _openRelayTunnel;
   late final InstanceRepository _repository = InstanceRepository(_store);
   final Duration relayRaceHeadstart;
+  final Future<void> Function(Duration duration)? relayRaceWait;
   bool _candidateRefreshInFlight = false;
 
   AppPhase phase = AppPhase.splash;
@@ -1094,6 +1097,7 @@ class AppController extends ChangeNotifier {
         return await probeRelay(relay);
       },
       headstart: relayRaceHeadstart,
+      wait: relayRaceWait ?? Future<void>.delayed,
     );
   }
 

--- a/apps/mobile_flutter/lib/data/app_controller.dart
+++ b/apps/mobile_flutter/lib/data/app_controller.dart
@@ -53,7 +53,7 @@ class AppController extends ChangeNotifier {
     OpenRelayTunnel? openRelayTunnel,
     ExternalBrowser? browser,
     Duration? relayRaceHeadstart,
-    Future<void> Function(Duration duration)? relayRaceWait,
+    this.relayRaceWait,
   })  : _store = store,
         _qrScanner = qrScanner ?? QrScanner(),
         _deepLinks = deepLinks ?? DeepLinkListener(),
@@ -62,8 +62,7 @@ class AppController extends ChangeNotifier {
         browser = browser ?? ExternalBrowser(),
         _instances = seed?.instances ?? const [],
         _activeId = seed?.activeId,
-        relayRaceHeadstart = relayRaceHeadstart ?? const Duration(milliseconds: 1500),
-        relayRaceWait = relayRaceWait {
+        relayRaceHeadstart = relayRaceHeadstart ?? const Duration(milliseconds: 1500) {
     _directTransport = _api.transport;
     _openRelayTunnel = openRelayTunnel ?? _defaultOpenRelay;
     remoteSettings = SettingsRemoteStore(

--- a/apps/mobile_flutter/lib/data/openchamber_api.dart
+++ b/apps/mobile_flutter/lib/data/openchamber_api.dart
@@ -993,6 +993,7 @@ class MemoryOpenChamberTransport implements OpenChamberTransport {
   Map<String, Object?> quotas = Map<String, Object?>.from(defaultTestQuotas);
 
   final List<OpenChamberRequest> calls = [];
+  final List<Uri> bases = [];
   final List<String> sentPrompts = [];
   final List<List<Map<String, Object?>>> sentPromptParts = [];
   final List<Map<String, Object?>> uploadedAttachments = [];
@@ -1422,6 +1423,7 @@ class MemoryOpenChamberTransport implements OpenChamberTransport {
   @override
   Future<OpenChamberResponse> send(Uri base, OpenChamberRequest request) async {
     calls.add(request);
+    bases.add(base);
     switch (request.path) {
       case OpenChamberPaths.health:
         final delay = healthDelayByHost[base.host] ?? healthDelay;

--- a/apps/mobile_flutter/lib/data/prompt_attachment.dart
+++ b/apps/mobile_flutter/lib/data/prompt_attachment.dart
@@ -98,6 +98,35 @@ bool needsHeicTranscode(String mime) {
   return lower == 'image/heic' || lower == 'image/heif';
 }
 
+class PreparedComposerAttachments {
+  const PreparedComposerAttachments({required this.ready, this.errorKey});
+
+  final List<AttachmentDraft> ready;
+  final String? errorKey;
+}
+
+/// Album/picker attach pipeline: HEIC/HEIF → JPEG via [transcodeHeic], then
+/// the official 25 MiB upload cap. Preview publish stays in the composer.
+Future<PreparedComposerAttachments> prepareComposerAttachments({
+  required List<AttachmentDraft> picked,
+  required Future<AttachmentDraft> Function(AttachmentDraft draft) transcodeHeic,
+}) async {
+  final ready = <AttachmentDraft>[];
+  String? errorKey;
+  for (final draft in picked) {
+    var next = draft;
+    if (needsHeicTranscode(next.mime)) {
+      next = await transcodeHeic(next);
+    }
+    if (next.bytes.length > maxPromptAttachmentBytes) {
+      errorKey = 'chat.error.attachmentTooLarge';
+      continue;
+    }
+    ready.add(next);
+  }
+  return PreparedComposerAttachments(ready: ready, errorKey: errorKey);
+}
+
 Future<PromptAttachmentUploadResult> uploadPromptAttachmentBytes({
   required OpenChamberApi api,
   required Uri base,

--- a/apps/mobile_flutter/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_flutter/lib/features/chat/chat_screen.dart
@@ -158,22 +158,21 @@ class _ChatScreenState extends State<ChatScreen> {
   Future<void> _attach() async {
     try {
       final picked = await _media.pickImages();
-      final ready = <AttachmentDraft>[];
-      for (final draft in picked) {
-        var next = draft;
-        if (next.isHeic) {
-          next = await _media.transcodeHeic(next);
-        }
-        if (next.bytes.length > maxPromptAttachmentBytes) {
-          if (mounted) _errorKey.value = 'chat.error.attachmentTooLarge';
-          continue;
-        }
-        await _media.publishVirtualAsset(next);
-        ready.add(next);
+      final prepared = await prepareComposerAttachments(
+        picked: picked,
+        transcodeHeic: _media.transcodeHeic,
+      );
+      if (!mounted) return;
+      if (prepared.ready.isEmpty) {
+        if (prepared.errorKey != null) _errorKey.value = prepared.errorKey;
+        return;
       }
-      if (!mounted || ready.isEmpty) return;
+      for (final draft in prepared.ready) {
+        await _media.publishVirtualAsset(draft);
+      }
+      if (!mounted) return;
       setState(() {
-        _attachments.addAll(ready);
+        _attachments.addAll(prepared.ready);
       });
       _errorKey.value = null;
     } on PromptAttachmentUploadError {

--- a/apps/mobile_flutter/test/composer_attachments_test.dart
+++ b/apps/mobile_flutter/test/composer_attachments_test.dart
@@ -1,11 +1,9 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openchamber/data/app_controller.dart';
 import 'package:openchamber/data/openchamber_api.dart';
-import 'package:openchamber/data/openchamber_http.dart';
 import 'package:openchamber/data/prompt_attachment.dart';
 import 'package:openchamber/data/secure_store.dart';
 import 'package:openchamber/native/media_channel.dart';
@@ -18,7 +16,7 @@ void main() {
     expect(needsHeicTranscode('image/heic'), isTrue);
     expect(needsHeicTranscode('image/HEIF'), isTrue);
     expect(needsHeicTranscode(' image/heif '), isTrue);
-    expect(const AttachmentDraft(name: 'a.heic', mime: 'image/heic', bytes: Uint8List(0)).isHeic, isTrue);
+    expect(AttachmentDraft(name: 'a.heic', mime: 'image/heic', bytes: Uint8List(0)).isHeic, isTrue);
     expect(needsHeicTranscode('image/jpeg'), isFalse);
     expect(needsHeicTranscode('image/png'), isFalse);
     expect(needsHeicTranscode('application/octet-stream'), isFalse);

--- a/apps/mobile_flutter/test/composer_attachments_test.dart
+++ b/apps/mobile_flutter/test/composer_attachments_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openchamber/data/app_controller.dart';
+import 'package:openchamber/data/openchamber_api.dart';
+import 'package:openchamber/data/openchamber_http.dart';
+import 'package:openchamber/data/prompt_attachment.dart';
+import 'package:openchamber/data/secure_store.dart';
+import 'package:openchamber/native/media_channel.dart';
+import 'package:openchamber/native/platform_channels.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('HEIC/HEIF mimes need JPEG transcode; JPEG does not', () {
+    expect(needsHeicTranscode('image/heic'), isTrue);
+    expect(needsHeicTranscode('image/HEIF'), isTrue);
+    expect(needsHeicTranscode(' image/heif '), isTrue);
+    expect(const AttachmentDraft(name: 'a.heic', mime: 'image/heic', bytes: Uint8List(0)).isHeic, isTrue);
+    expect(needsHeicTranscode('image/jpeg'), isFalse);
+    expect(needsHeicTranscode('image/png'), isFalse);
+    expect(needsHeicTranscode('application/octet-stream'), isFalse);
+  });
+
+  test('prepareComposerAttachments transcodes HEIC then keeps JPEG bytes for upload', () async {
+    final heic = AttachmentDraft(
+      name: 'IMG_0001.HEIC',
+      mime: 'image/heic',
+      bytes: Uint8List.fromList(List<int>.filled(32, 9)),
+    );
+    final jpeg = AttachmentDraft(
+      name: 'keep.jpg',
+      mime: 'image/jpeg',
+      bytes: Uint8List.fromList(List<int>.filled(8, 3)),
+    );
+    var transcodeCalls = 0;
+    final prepared = await prepareComposerAttachments(
+      picked: [heic, jpeg],
+      transcodeHeic: (draft) async {
+        transcodeCalls += 1;
+        expect(draft.mime, 'image/heic');
+        return AttachmentDraft(
+          name: 'IMG_0001.jpg',
+          mime: 'image/jpeg',
+          bytes: Uint8List.fromList(List<int>.filled(16, 4)),
+        );
+      },
+    );
+    expect(transcodeCalls, 1);
+    expect(prepared.errorKey, isNull);
+    expect(prepared.ready, hasLength(2));
+    expect(prepared.ready.first.mime, 'image/jpeg');
+    expect(prepared.ready.first.name, 'IMG_0001.jpg');
+    expect(prepared.ready.first.bytes, Uint8List.fromList(List<int>.filled(16, 4)));
+    expect(prepared.ready.last.mime, 'image/jpeg');
+    expect(prepared.ready.last.bytes, jpeg.bytes);
+  });
+
+  test('prepareComposerAttachments skips oversized drafts and does not fake success', () async {
+    final huge = AttachmentDraft(
+      name: 'huge.jpg',
+      mime: 'image/jpeg',
+      bytes: Uint8List(maxPromptAttachmentBytes + 1),
+    );
+    final ok = AttachmentDraft(
+      name: 'ok.jpg',
+      mime: 'image/jpeg',
+      bytes: Uint8List.fromList([1, 2, 3]),
+    );
+    final prepared = await prepareComposerAttachments(
+      picked: [huge, ok],
+      transcodeHeic: (draft) async => draft,
+    );
+    expect(prepared.errorKey, 'chat.error.attachmentTooLarge');
+    expect(prepared.ready.single.name, 'ok.jpg');
+  });
+
+  test('MediaChannel.transcodeHeic renames HEIC and returns JPEG from the native contract', () async {
+    const channel = MethodChannel(OpenChamberChannels.media);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'transcode');
+      final args = Map<String, Object?>.from(call.arguments as Map);
+      expect(args['mime'], 'image/heic');
+      expect(args['quality'], 0.9);
+      expect(args['data'], isA<String>());
+      return {
+        'data': base64Encode(List<int>.filled(12, 11)),
+        'mime': 'image/jpeg',
+      };
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    });
+
+    final media = MediaChannel();
+    final result = await media.transcodeHeic(
+      AttachmentDraft(
+        name: 'album.HEIC',
+        mime: 'image/heic',
+        bytes: Uint8List.fromList([1, 2, 3, 4]),
+      ),
+    );
+    expect(result.mime, 'image/jpeg');
+    expect(result.name, 'album.jpg');
+    expect(result.bytes, Uint8List.fromList(List<int>.filled(12, 11)));
+
+    final passthrough = await media.transcodeHeic(
+      AttachmentDraft(name: 'plain.jpg', mime: 'image/jpeg', bytes: Uint8List.fromList([9])),
+    );
+    expect(passthrough.mime, 'image/jpeg');
+    expect(passthrough.name, 'plain.jpg');
+    expect(passthrough.bytes, Uint8List.fromList([9]));
+  });
+
+  test('sendPrompt after HEIC→JPEG prepare uses official prompt-attachments and file:// parts', () async {
+    final transport = MemoryOpenChamberTransport();
+    final api = OpenChamberApi(transport: transport);
+    final controller = AppController(store: MemorySecureStore(), api: api);
+    await controller.bootstrap(skipDelay: true);
+    await controller.connect(url: 'http://192.168.1.74:2606');
+    await controller.refreshSessions();
+    final session = controller.sessions.firstWhere((row) => row.id == 'sess-catalog');
+
+    final heic = AttachmentDraft(
+      name: 'photo.heic',
+      mime: 'image/heic',
+      bytes: Uint8List.fromList(List<int>.filled(24, 5)),
+    );
+    final jpegBytes = Uint8List.fromList(List<int>.filled(10, 8));
+    final prepared = await prepareComposerAttachments(
+      picked: [heic],
+      transcodeHeic: (draft) async => AttachmentDraft(
+        name: 'photo.jpg',
+        mime: 'image/jpeg',
+        bytes: jpegBytes,
+      ),
+    );
+    expect(prepared.ready.single.mime, 'image/jpeg');
+
+    await controller.sendPrompt(
+      session: session,
+      messageId: 'msg-heic',
+      text: 'see album',
+      attachments: prepared.ready,
+    );
+
+    final upload = transport.calls.firstWhere((call) => call.path.startsWith('/api/fs/prompt-attachments/'));
+    expect(upload.method, 'PUT');
+    expect(upload.bytes, jpegBytes);
+    expect(upload.extraHeaders['X-OpenChamber-Mime'], 'image/jpeg');
+    expect(upload.extraHeaders['X-OpenChamber-Sha256'], sha256Hex(jpegBytes));
+    expect(upload.extraHeaders['X-OpenChamber-Content-Length'], '${jpegBytes.length}');
+    expect(transport.sentPromptParts.single.any((part) => part['type'] == 'file'), isTrue);
+    expect(transport.sentPromptParts.single.any((part) => part['mime'] == 'image/jpeg'), isTrue);
+    expect(transport.sentPromptParts.single.any((part) => part['url']?.toString().startsWith('file://') == true), isTrue);
+    expect(transport.sentPromptParts.single.any((part) => part['url']?.toString().startsWith('data:') == true), isFalse);
+    expect(transport.sentPromptParts.single.any((part) => part['url']?.toString().startsWith('blob:') == true), isFalse);
+    expect(transport.sentPrompts, ['see album']);
+  });
+}

--- a/apps/mobile_flutter/test/connection_candidates_test.dart
+++ b/apps/mobile_flutter/test/connection_candidates_test.dart
@@ -260,10 +260,15 @@ void main() {
         'server': {'label': 'Studio'},
       };
     final hostKeys = generateEcdhKeyPair();
+    var waited = false;
     final controller = AppController(
       store: MemorySecureStore(),
       api: OpenChamberApi(transport: http),
       relayRaceHeadstart: const Duration(seconds: 5),
+      relayRaceWait: (duration) async {
+        waited = true;
+        await Future<void>.delayed(duration);
+      },
       openRelayTunnel: (relay) => _openMemoryTunnel(http, hostKeys),
     );
     await controller.bootstrap(skipDelay: true);
@@ -284,8 +289,10 @@ void main() {
     final started = Stopwatch()..start();
     expect(await controller.connect(pairingLink: encoded), isTrue);
     started.stop();
-    expect(started.elapsed, lessThan(const Duration(milliseconds: 1500)));
+    expect(waited, isFalse);
+    expect(started.elapsed, lessThan(const Duration(milliseconds: 500)));
     expect(controller.connectErrorKey, isNull);
+    expect(controller.connectErrorKey, isNot(equals('connect.error.unreachable')));
     expect(controller.activeTransportKind, ActiveTransportKind.relay);
     expect(controller.activeConnectionStatusKey, 'mobile.instances.status.connectedRelay');
     expect(
@@ -299,6 +306,13 @@ void main() {
     expect(controller.activeConnectionStatusKey, isNot(contains('connectedDirect')));
     expect(controller.activeInstance?.url, 'relay://srv_test');
     expect(directCandidatesOf(controller.activeInstance!.transportCandidates), isEmpty);
+    expect(http.calls.any((call) => call.path == OpenChamberPaths.pairingRedeem), isTrue);
+    expect(
+      http.calls.any((call) => call.path == OpenChamberPaths.pairingRedeem && call.body?['pairingId'] == 'pair_relay_only_walk'),
+      isTrue,
+    );
+    expect(http.bases.any((base) => base.host.startsWith('192.168.')), isFalse);
+    expect(http.bases.any((base) => base.host == '127.0.0.1' || base.host == 'localhost'), isFalse);
   });
 }
 

--- a/apps/mobile_flutter/test/oauth_callback_test.dart
+++ b/apps/mobile_flutter/test/oauth_callback_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openchamber/data/app_controller.dart';
+import 'package:openchamber/data/oauth.dart';
+import 'package:openchamber/data/openchamber_api.dart';
+import 'package:openchamber/data/secure_store.dart';
+import 'package:openchamber/native/deep_link.dart';
+import 'package:openchamber/native/external_browser.dart';
+
+void main() {
+  test('parses provider and MCP openchamber callback query strings', () {
+    final provider = parseOAuthCallbackUri('openchamber://oauth/callback?code=prov-code&state=st-1&server=lan');
+    expect(provider.hasCode, isTrue);
+    expect(provider.code, 'prov-code');
+    expect(provider.state, 'st-1');
+    expect(provider.server, 'lan');
+    expect(provider.error, isNull);
+
+    final mcp = parseOAuthCallbackUri(
+      'openchamber://mcp/oauth/callback?code=mcp%2Fcode&state=mcp-state-1',
+    );
+    expect(mcp.hasCode, isTrue);
+    expect(mcp.code, 'mcp/code');
+    expect(mcp.state, 'mcp-state-1');
+
+    expect(isOAuthCallbackLink('openchamber://oauth/callback?code=abc'), isTrue);
+    expect(isOAuthCallbackLink('openchamber://mcp/oauth/callback?code=x&state=s'), isTrue);
+    expect(classifyDeepLink('openchamber://oauth/callback?code=abc').kind, DeepLinkKind.oauth);
+    expect(classifyDeepLink('openchamber://mcp/oauth/callback?code=x&state=s').kind, DeepLinkKind.oauth);
+  });
+
+  test('parses error callbacks and ignores empty codes', () {
+    final denied = parseOAuthCallbackUri(
+      'openchamber://oauth/callback?error=access_denied&error_description=User%20denied',
+    );
+    expect(denied.hasCode, isFalse);
+    expect(denied.error, 'access_denied');
+    expect(denied.errorDescription, 'User denied');
+
+    final blank = parseOAuthCallbackUri('openchamber://oauth/callback?code=%20&state=');
+    expect(blank.hasCode, isFalse);
+    expect(blank.code, isNull);
+    expect(blank.state, isNull);
+
+    expect(parseOAuthCallbackUri('not a url').hasCode, isFalse);
+    expect(isOAuthCallbackLink('openchamber://connect?v=2&p=abc'), isFalse);
+    expect(classifyDeepLink('https://example.invalid/oauth/callback?code=x').kind, DeepLinkKind.oauth);
+  });
+
+  test('official authorize URLs are http(s) only for the external browser', () async {
+    final browser = MemoryExternalBrowser();
+    expect(() => browser.open('openchamber://oauth/callback?code=abc'), throwsA(isA<ExternalBrowserException>()));
+    expect(() => browser.open('javascript:alert(1)'), throwsA(isA<ExternalBrowserException>()));
+    expect(() => browser.open('file:///tmp/secret'), throwsA(isA<ExternalBrowserException>()));
+    expect(() => browser.open('https://'), throwsA(isA<ExternalBrowserException>()));
+    expect(() => browser.open('ftp://example.invalid/oauth'), throwsA(isA<ExternalBrowserException>()));
+
+    await browser.open('https://example.invalid/oauth/provider?state=s');
+    await browser.open('http://127.0.0.1:4280/oauth');
+    expect(browser.opened, [
+      'https://example.invalid/oauth/provider?state=s',
+      'http://127.0.0.1:4280/oauth',
+    ]);
+  });
+
+  test('incoming callback URI is stored then consumed exactly once', () async {
+    final controller = AppController(
+      store: MemorySecureStore(),
+      api: OpenChamberApi(transport: MemoryOpenChamberTransport()),
+      browser: MemoryExternalBrowser(),
+    );
+    await controller.bootstrap(skipDelay: true);
+    await controller.handleIncomingLink('openchamber://oauth/callback?code=once-code&state=once-state');
+    expect(controller.pendingOAuthCallback?.code, 'once-code');
+    expect(controller.pendingOAuthCallback?.state, 'once-state');
+    expect(controller.takeOAuthCallback()?.code, 'once-code');
+    expect(controller.pendingOAuthCallback, isNull);
+    expect(controller.takeOAuthCallback(), isNull);
+  });
+}

--- a/apps/mobile_flutter/test/pairing_payload_test.dart
+++ b/apps/mobile_flutter/test/pairing_payload_test.dart
@@ -198,7 +198,7 @@ void main() {
     expect(http.bases.any((base) => base.host.startsWith('192.168.')), isFalse);
   });
 
-  testWidgets('relay-only pairing form redeems and shows Connected · Relay', (tester) async {
+  testWidgets('relay-only redeem paints Connected · Relay then 已连接 · 中继', (tester) async {
     final http = MemoryOpenChamberTransport()
       ..redeem = {
         'ok': true,
@@ -217,9 +217,6 @@ void main() {
       openRelayTunnel: (relay) => _openMemoryTunnel(http, hostKeys),
     );
     await controller.bootstrap(skipDelay: true);
-    await tester.pumpWidget(OpenChamberApp(controller: controller));
-    await tester.pumpAndSettle();
-
     final encoded = encodePairingConnectionPayload(
       PairingConnectionPayload(
         pairingId: 'pair_widget_redeem',
@@ -234,13 +231,13 @@ void main() {
         ],
       ),
     );
-    await tester.enterText(find.byKey(const Key('connect-pairing')), encoded);
-    await tester.tap(find.byKey(const Key('connect-submit')));
-    await tester.pumpAndSettle();
-
+    expect(await controller.connect(pairingLink: encoded), isTrue);
     expect(waited, isFalse);
     expect(controller.phase, AppPhase.shell);
     expect(controller.activeConnectionStatusKey, 'mobile.instances.status.connectedRelay');
+
+    await tester.pumpWidget(OpenChamberApp(controller: controller));
+    await tester.pumpAndSettle();
     expect(find.text('Connected · Relay'), findsNothing);
 
     await tester.tap(find.byKey(const Key('tab-settings')));

--- a/apps/mobile_flutter/test/pairing_payload_test.dart
+++ b/apps/mobile_flutter/test/pairing_payload_test.dart
@@ -1,9 +1,15 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openchamber/app.dart';
 import 'package:openchamber/data/app_controller.dart';
 import 'package:openchamber/data/openchamber_api.dart';
 import 'package:openchamber/data/openchamber_http.dart';
 import 'package:openchamber/data/pairing_payload.dart';
+import 'package:openchamber/data/relay/crypto.dart';
+import 'package:openchamber/data/relay/handshake.dart';
+import 'package:openchamber/data/relay/tunnel_client.dart';
 import 'package:openchamber/data/secure_store.dart';
+import 'package:openchamber/l10n/app_strings.dart';
 
 void main() {
   const hostEncPubJwk = {'kty': 'EC', 'crv': 'P-256', 'x': 'eHhY', 'y': 'eVlZ'};
@@ -111,4 +117,163 @@ void main() {
     expect(controller.phase, AppPhase.connect);
     expect(controller.connectErrorKey, 'connect.error.relayTunnelMissing');
   });
+
+  test('parses a relay-only v2 payload without inventing a LAN candidate', () {
+    final encoded = encodePairingConnectionPayload(
+      const PairingConnectionPayload(
+        pairingId: 'pair_relay_v2',
+        secret: 'one-time-secret',
+        label: 'Anywhere',
+        candidates: [
+          PairingRelayCandidate(
+            relayUrl: 'wss://relay.example/ws',
+            serverId: 'srv_away',
+            hostEncPubJwk: hostEncPubJwk,
+            grant: 'grant-away',
+          ),
+        ],
+      ),
+    );
+    expect(encoded.startsWith('openchamber://connect?v=2&p='), isTrue);
+    final parsed = parsePairingConnectionPayload(encoded);
+    expect(parsed, isNotNull);
+    expect(parsed!.pairingId, 'pair_relay_v2');
+    expect(parsed.secret, 'one-time-secret');
+    expect(parsed.firstDirectUrl, isNull);
+    expect(parsed.firstRelayUrl, 'wss://relay.example/ws');
+    expect(parsed.firstRelay?.serverId, 'srv_away');
+    expect(parsed.firstRelay?.grant, 'grant-away');
+    expect(parsed.candidates, hasLength(1));
+    expect(parsed.candidates.single, isA<PairingRelayCandidate>());
+  });
+
+  test('relay-only v2 redeem happy path hits official pairing redeem', () async {
+    final store = MemorySecureStore();
+    final http = MemoryOpenChamberTransport()
+      ..redeem = {
+        'ok': true,
+        'clientToken': 'oc_client_pair',
+        'server': {'label': 'Studio'},
+      };
+    final hostKeys = generateEcdhKeyPair();
+    var waited = false;
+    final controller = AppController(
+      store: store,
+      api: OpenChamberApi(transport: http),
+      relayRaceHeadstart: const Duration(seconds: 5),
+      relayRaceWait: (_) async {
+        waited = true;
+      },
+      openRelayTunnel: (relay) => _openMemoryTunnel(http, hostKeys),
+    );
+    await controller.bootstrap(skipDelay: true);
+    final encoded = encodePairingConnectionPayload(
+      PairingConnectionPayload(
+        pairingId: 'pair_redeem_v2',
+        secret: 'one-time-secret',
+        label: 'Studio',
+        candidates: [
+          PairingRelayCandidate(
+            relayUrl: 'wss://relay.example/ws',
+            serverId: 'srv_test',
+            hostEncPubJwk: hostKeys.publicJwk,
+            grant: 'grant-redeem',
+          ),
+        ],
+      ),
+    );
+    expect(await controller.connect(pairingLink: encoded), isTrue);
+    expect(waited, isFalse);
+    expect(controller.phase, AppPhase.shell);
+    expect(controller.activeTransportKind, ActiveTransportKind.relay);
+    expect(controller.activeInstance?.clientToken, 'oc_client_pair');
+    expect(controller.activeInstance?.pairingId, 'pair_redeem_v2');
+    expect(controller.activeInstance?.grant, 'grant-redeem');
+    expect(controller.activeInstance?.relayUrl, 'wss://relay.example/ws');
+    final redeem = http.calls.singleWhere((call) => call.path == OpenChamberPaths.pairingRedeem);
+    expect(redeem.method, 'POST');
+    expect(redeem.body?['pairingId'], 'pair_redeem_v2');
+    expect(redeem.body?['secret'], 'one-time-secret');
+    expect(redeem.body?['clientKind'], 'mobile');
+    expect(http.bases.any((base) => base.host.startsWith('192.168.')), isFalse);
+  });
+
+  testWidgets('relay-only pairing form redeems and shows Connected · Relay', (tester) async {
+    final http = MemoryOpenChamberTransport()
+      ..redeem = {
+        'ok': true,
+        'clientToken': 'oc_client_pair',
+        'server': {'label': 'Studio'},
+      };
+    final hostKeys = generateEcdhKeyPair();
+    var waited = false;
+    final controller = AppController(
+      store: MemorySecureStore(),
+      api: OpenChamberApi(transport: http),
+      relayRaceHeadstart: const Duration(seconds: 5),
+      relayRaceWait: (_) async {
+        waited = true;
+      },
+      openRelayTunnel: (relay) => _openMemoryTunnel(http, hostKeys),
+    );
+    await controller.bootstrap(skipDelay: true);
+    await tester.pumpWidget(OpenChamberApp(controller: controller));
+    await tester.pumpAndSettle();
+
+    final encoded = encodePairingConnectionPayload(
+      PairingConnectionPayload(
+        pairingId: 'pair_widget_redeem',
+        secret: 'one-time-secret',
+        label: 'Studio',
+        candidates: [
+          PairingRelayCandidate(
+            relayUrl: 'wss://relay.example/ws',
+            serverId: 'srv_test',
+            hostEncPubJwk: hostKeys.publicJwk,
+          ),
+        ],
+      ),
+    );
+    await tester.enterText(find.byKey(const Key('connect-pairing')), encoded);
+    await tester.tap(find.byKey(const Key('connect-submit')));
+    await tester.pumpAndSettle();
+
+    expect(waited, isFalse);
+    expect(controller.phase, AppPhase.shell);
+    expect(controller.activeConnectionStatusKey, 'mobile.instances.status.connectedRelay');
+    expect(find.text('Connected · Relay'), findsNothing);
+
+    await tester.tap(find.byKey(const Key('tab-settings')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const Key('settings-slug-instances')));
+    await tester.tap(find.byKey(const Key('settings-slug-instances')));
+    await tester.pumpAndSettle();
+    expect(find.text('Connected · Relay'), findsOneWidget);
+    expect(find.text('Connected · Local network'), findsNothing);
+    expect(find.text('已连接 · 中继'), findsNothing);
+
+    await controller.setLocale(AppStrings.zhCN);
+    await tester.pumpAndSettle();
+    expect(find.text('已连接 · 中继'), findsOneWidget);
+    expect(find.text('Connected · Relay'), findsNothing);
+    expect(http.calls.any((call) => call.path == OpenChamberPaths.pairingRedeem), isTrue);
+  });
+}
+
+Future<OpenChamberTransport> _openMemoryTunnel(
+  MemoryOpenChamberTransport http,
+  RelayKeyPair hostKeys,
+) async {
+  final pair = MemoryTunnelPair();
+  MemoryRelayHost(
+    handshake: HostHandshake(hostKeys.privateKey),
+    wire: pair.host,
+    handler: (request) => http.send(Uri.parse('http://memory.invalid'), request),
+  );
+  final tunnel = RelayTunnelTransport(
+    wire: pair.client,
+    handshake: ClientHandshake.create(hostKeys.publicJwk),
+  );
+  await tunnel.establish();
+  return tunnel;
 }

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -72,7 +72,7 @@ Native contracts / shell
 | Appearance `iosNativeUi` | **not present** | Do not rebuild. Native is always on. |
 | Plan mode / project notes / Todo | **not present** | Removed in 1.19.2. Do not rebuild. |
 | Capgo OTA | **not ported** | WebView web-bundle hot update only. Flutter ships IPA/APK. |
-| Flutter CI | landed | `.github/workflows/flutter-mobile-ci.yml` automatic on this track. **#13** `332ad6f82` and **#14** `77baf9b6f` both fully green (analyze + Android APK + iOS simulator). **#15** `10f97ff86` iOS simulator **failed** (`OpenChamberFlutterPlugins.swift:598` missing `await` on MainActor `mime`). **#16** `37074feea` fully green: https://github.com/yee94/openchambery/actions/runs/33715865698. **#17** `1f32bed56` fully green: https://github.com/yee94/openchambery/actions/runs/33716649360. **#18** `74aec2072` fully green: https://github.com/yee94/openchambery/actions/runs/33717269010. **#19** `17d1822bc` cancelled by the next push. **#20** `d740f4164` fully green (analyze + Android debug APK + iOS simulator): https://github.com/yee94/openchambery/actions/runs/33718295396. Linux analyze-test alone is never treated as green. |
+| Flutter CI | landed | `.github/workflows/flutter-mobile-ci.yml` automatic on this track. Linux analyze-test alone is never treated as green. Latest fully green tip: **`915c22dc5`** run **33862397899** (analyze + Android debug APK + iOS simulator): https://github.com/yee94/openchambery/actions/runs/33862397899. Prior fully green: **#16** `37074feea` / **#17** `1f32bed56` / **#18** `74aec2072` / **#20** `d740f4164`. **#15** `10f97ff86` iOS red — do not cite. |
 | Signed release workflow | landed | `.github/workflows/flutter-mobile-release.yml` — existing secret names only |
 
 ## Settings slug checklist (`MOBILE_SETTINGS_PAGE_SLUGS`)
@@ -208,13 +208,22 @@ What still keys off the **base** id / class namespace (not broken by the suffix)
 
 **FCM:** `apps/mobile_flutter/android/app/google-services.json` already lists both `com.yee94.openchamber` and `com.yee94.openchamber.debug` (copied from Capacitor; Firebase project `openchamber-8bf7e`; no new secrets / no second project). The Google Services plugin can select the debug client. The native channel still returns **null** if Firebase init or token fetch fails — not a fake token. If a device walk sees no push token, treat that row as skipped for the v2 debug APK.
 
-**Relay-only:** a pairing payload with no LAN candidate calls `probeRelay` immediately (`hasDirect == false`). No 1.5s headstart, no LAN probe, no “LAN failed” / `connect.error.unreachable` from a missing LAN host. Status is `已连接 · 中继` / `Connected · Relay`. Covered by fake-transport tests in `connection_candidates_test.dart`. Do not run live `wss://` from CI.
+**Relay-only:** a pairing payload with no LAN candidate calls `probeRelay` immediately (`hasDirect == false`). No 1.5s headstart, no LAN probe, no “LAN failed” / `connect.error.unreachable` from a missing LAN host. Status is `已连接 · 中继` / `Connected · Relay`. Covered by fake-transport tests in `connection_candidates_test.dart` and `pairing_payload_test.dart` (including a widget redeem that paints the status string). Injected `relayRaceWait` must stay uncalled. Do not run live `wss://` from CI.
 
 ### Download and install (GitHub login required)
 
+Preferred: the GitHub **prerelease** (no Actions Artifacts UI):
+
+- Tag `flutter-v2-debug-915c22d` (prerelease, not draft): https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-915c22d
+- APK: https://github.com/yee94/openchambery/releases/download/flutter-v2-debug-915c22d/openchamber-v2-debug-915c22d.apk
+- Built from `915c22dc5` / Flutter Mobile CI [run 33862397899](https://github.com/yee94/openchambery/actions/runs/33862397899) (analyze + Android debug APK + iOS simulator all green)
+- Includes voice UI removal + standard IME keyboard. Side-by-side `com.yee94.openchamber.debug` / **OpenChamber v2**. Relay-first walk — Yee has no LAN.
+
+Actions artifact fallback (14-day retention):
+
 1. Open the Flutter Mobile CI run for this commit (Actions → **Flutter Mobile CI** on `work/flutter-native`, or **Run workflow**).
 2. Wait until **Android debug APK** is green. Heavy concurrency **cancels** older runs on a newer push — if cancelled, re-dispatch instead of installing an older artifact.
-3. Artifacts → `openchamber-flutter-android-debug-apk-<shortsha>` (zip, 14-day retention, not a GitHub Release). **#21** `d13c8f4ac` ([run 33768888525](https://github.com/yee94/openchambery/actions/runs/33768888525)) was cancelled by the next visual push. **#22** `38dba5042` ([run 33769081194](https://github.com/yee94/openchambery/actions/runs/33769081194)) analyze + iOS green; Android debug APK failed on Maven Central **429** (not the new applicationId). Re-dispatch / retry the Android job — do not install from a cancelled or red run.
+3. Artifacts → `openchamber-flutter-android-debug-apk-<shortsha>` (zip). Do not install from a cancelled or red run.
 4. Unzip. Install `openchamber-v2-debug-<shortsha>.apk` (unknown-sources / adb). Official **OpenChamber** stays installed.
 5. Pair with an **Anywhere** / relay (`wss`) payload. Do not require a `192.168.x` host.
 
@@ -361,6 +370,21 @@ Read on main (do not invent): skill grouping is `isSkillGroupTool` + `SkillToolG
 4. Pierre `@pierre/diffs` / `beautiful-mermaid` SVG — will not add packages.
 5. Experimental session-list fallback when index returns 501 — not a 1.19 mobile happy path.
 6. Official nearby is LAN / home network (`mobileConnections.ts`). There is **no** 「附近」 string and **no** Bonjour/mDNS/NWBrowser/NSD — do not add a scanner UI.
+
+## Acceptance board (connect / media — still ❌ 真机过)
+
+Automated coverage on Linux / Flutter 3.32.8 does **not** make a row 真机过. Phone-only rows stay ❌.
+
+| Row | Automated | 真机过 | Evidence / residual |
+|---|---|---|---|
+| Relay-only pair (no LAN candidate) skips 1.5s headstart | ✅ | ❌ | `probeConnectionCandidates(hasDirect: false)` + AppController `relayRaceWait` never called. Fake tunnel only. |
+| Status `已连接 · 中继` / `Connected · Relay` | ✅ | ❌ | Unit + settings Instances widget after v2 redeem. Not a live `wss://` phone. |
+| Pairing v2 redeem happy path | ✅ | ❌ | `POST /api/client-auth/pairing/redeem` on the winning memory tunnel. Widget form submit. |
+| Album HEIC → JPEG + `PUT /api/fs/prompt-attachments` `file://` | ✅ | ❌ | `prepareComposerAttachments` + mocked `transcode` channel + sendPrompt. No PHPicker / Photo Picker on a device. |
+| OAuth external-browser callback URL parse | ✅ | ❌ | Query `code`/`state`/`error`, http(s)-only `open`. Live hosted-provider/MCP browser round-trip still device-only. |
+| IME / voice removal on this APK | ✅ contract | ❌ | Debug APK `915c22d` includes IME Scaffold + no Voice page. Not walked on Yee's phone from this VM. |
+| Home ↔ away relay hot-switch on a phone | ✅ memory | ❌ | Candidates refresh + reprobe are fake-transport only. |
+| iOS Local Network prompt | plist only | ❌ | `NSLocalNetworkUsageDescription` present. Prompt not shown here. |
 
 ## Tenth-slice status
 
@@ -574,3 +598,15 @@ Budget on a real device: settled scroll should stay near 16ms UI frames; a live 
 3. Encrypted/redacted reasoning with empty text stays hidden (same as official empty-text hide). No placeholder “encrypted thinking” chip.
 4. `WidgetTester` rebuild counters and CI CPU budgets are not a systrace on a mid-range Android phone. Phone-only residual: Impeller raster, glyph cache, and large-fence decode on a physical GPU.
 5. Pixel/golden chrome (composer glass, dock, goldens) stays on the Flutter UI track. This slice did not recapture `docs/flutter-native-screenshots/*`.
+
+## Sixteenth-slice status (connect/media acceptance, no 真机过 claim)
+
+Close automated gaps that do not need Yee's phone. Visual goldens / pixel chrome were not retouched.
+
+| Surface | Status | Notes |
+|---|---|---|
+| Relay-only wait skip | landed (memory) | `AppController.relayRaceWait` is uncalled when LAN candidates are absent. Elapsed stays well under 1.5s even with a 5s headstart. |
+| Pairing v2 redeem | landed (memory + widget) | Parse-only-relay payload; `POST /api/client-auth/pairing/redeem`; Instances page shows `Connected · Relay` / `已连接 · 中继`. |
+| HEIC attach plumbing | landed (memory) | `prepareComposerAttachments` owns HEIC→JPEG + 25 MiB cap. Composer still publishes virtual assets. `sendPrompt` keeps official PUT headers + `file://` parts. |
+| OAuth callback URLs | landed (unit) | Query `code`/`state`/`error`; http(s)-only external browser. Live system-browser OAuth remains ❌ 真机过. |
+| Debug APK prerelease | published | `flutter-v2-debug-915c22d` from CI run 33862397899 / `915c22dc5`. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Independent Flutter track only. **Do not merge to `main`.** Lands on `work/flutter-native` / Draft PR #5 after review.

## A) APK prerelease (already published)

Latest fully green Flutter Mobile CI on `work/flutter-native` tip `915c22dc5`:

- CI: https://github.com/yee94/openchambery/actions/runs/33862397899 (analyze + Android debug APK + iOS simulator)
- Prerelease: https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-915c22d
- APK: https://github.com/yee94/openchambery/releases/download/flutter-v2-debug-915c22d/openchamber-v2-debug-915c22d.apk

Notes on the release: voice UI removal + standard IME keyboard; side-by-side `com.yee94.openchamber.debug` / **OpenChamber v2**; relay-first walk (no LAN).

## B) Acceptance hardening (this PR)

Closes automated gaps that do **not** need Yee's phone. Still **❌ 真机过**.

- Relay-only pairing: injected `relayRaceWait` stays uncalled; no 1.5s fake LAN wait; status `已连接 · 中继` / `Connected · Relay`
- Pairing v2 redeem happy path (unit + Instances widget)
- HEIC → JPEG `prepareComposerAttachments` + prompt-attachments `file://` plumbing
- OAuth external-browser callback URL parsing (query code/state/error, http(s) only)

No golden/pixel chrome. `.debug` `applicationIdSuffix` unchanged.

## Validation (this revision)

- Flutter **3.32.8** / Dart 3.8.1
- `flutter analyze --no-fatal-infos` — only pre-existing infos in `theme_tokens_test.dart`
- `flutter test` — **163 passed** (full suite, including new files)

Flutter Mobile CI YAML only auto-runs on push to `work/flutter-native`. This PR targets that branch; merge there to get the three-job CI.

## Residual 真机 gaps

Live `wss://` phone pair, home↔away hot-switch, iOS Local Network prompt, hosted-provider/MCP system-browser OAuth, album PHPicker/Photo Picker on a device.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2222f847-aee7-4066-be8b-1c4ca61753ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2222f847-aee7-4066-be8b-1c4ca61753ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

