### PR TITLE
fix(flutter): compile Android APK without FlutterFire getInitialMessage

### DIFF
--- a/apps/mobile_flutter/android/app/src/main/kotlin/com/yee94/openchamber/NativePlugins.kt
+++ b/apps/mobile_flutter/android/app/src/main/kotlin/com/yee94/openchamber/NativePlugins.kt
@@ -89,8 +89,9 @@ object NativePlugins {
                 }
             }
         }
+        // Cold-start notification taps put FCM data on the launch intent.
+        // Native FirebaseMessaging has token, not FlutterFire's getInitialMessage().
         capturePushOpen(activity.intent)
-        readInitialFcmMessage()
         MethodChannel(messenger, "openchamber/widget_snapshot").setMethodCallHandler { call, result ->
             if (call.method == "setBadge" || call.method == "write") {
                 // Official push relay has no FCM send path (APNs aps.badge only).
@@ -140,27 +141,6 @@ object NativePlugins {
         val sessionId = map["sessionId"]?.toString().orEmpty().ifEmpty { map["sessionID"]?.toString().orEmpty() }
         if (url.isEmpty() && deeplink.isEmpty() && sessionId.isEmpty()) return null
         return map
-    }
-
-    private fun readInitialFcmMessage() {
-        try {
-            com.google.firebase.messaging.FirebaseMessaging.getInstance().getInitialMessage()
-                .addOnSuccessListener { message ->
-                    val data = message?.data ?: return@addOnSuccessListener
-                    if (data.isEmpty()) return@addOnSuccessListener
-                    val payload = data.mapValues { it.value }
-                    if (payload["url"].isNullOrEmpty() &&
-                        payload["deeplink"].isNullOrEmpty() &&
-                        payload["sessionId"].isNullOrEmpty() &&
-                        payload["sessionID"].isNullOrEmpty()
-                    ) {
-                        return@addOnSuccessListener
-                    }
-                    pendingPushOpen = payload
-                    pushChannel?.invokeMethod("opened", payload)
-                }
-        } catch (_: Exception) {
-        }
     }
 
     private fun argumentId(arguments: Any?, key: String): String {

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -664,7 +664,7 @@ Read on this checkout: `apps/mobile_flutter/**` vs `packages/ui/src/mobile/*`, `
 | Gap | Official | Flutter today | Next-agent prompt |
 |---|---|---|---|
 | **Share delivery** | `MobileShareBridge.tsx` `listPending` / `deliverOne` / recipient picker | **landed** Dart `ShareDelivery` + `ShareInbox` `listPending`/`ack`/`releaseFiles`/`listDrafts`. Catalog uses snapshot `assistant.id` + capability `serverInstanceID`. Recipient picker for untargeted Android drafts. | Device share-extension → inbox → POST is 真机-only. Composer handoff for assigned drafts is not this slice. |
-| **Push tap → session** | `deepLinkNavigation.ts` `pushNotificationActionPerformed` | **landed** `sessionDeepLinkFromPushData` + iOS `remoteNotification` / `didReceive` + Android intent extras / `getInitialMessage` → `openchamber://session/{id}` | Real APNs/FCM tap on a phone is still residual. |
+| **Push tap → session** | `deepLinkNavigation.ts` `pushNotificationActionPerformed` | **landed** `sessionDeepLinkFromPushData` + iOS `remoteNotification` / `didReceive` + Android launch/new-intent extras → `openchamber://session/{id}` | Real APNs/FCM tap on a phone is still residual. |
 | **HTML preview render** | Files iframe/WebView | **landed** preview mode `UiKitView`/`AndroidView` (`openchamber/html_preview_view`). Source stays selectable text. No new pub dep. | Scripted HTML / Impeller WebView compositing is 真机-only. |
 | **Chat context ring + quotas** | `MobileContextProgressButton.tsx` `buildMobileContextDisplay` | Stub `OcOptical.contextProgressStubPercent` (35%); metadata sheet branch-only | Live token/limit % + quota groups. |
 | **Session overflow actions** | `MobileRowActionsSheet.tsx` | `session_overflow_sheet.dart` + `_stubSessionAction` | Implement rename/pin/refresh/archive/delete against official session APIs. |
@@ -683,7 +683,7 @@ Closes the three code-gaps called out after the eighteenth slice. No merge to `m
 | Surface | Status | Notes |
 |---|---|---|
 | Share delivery | landed (Dart + native aliases) | `ShareDelivery.deliverOne` matches official admit → connect → capability/snapshot → POST `/share` → wait → binding check → ack → releaseFiles. Drain concurrency 1; one failure yields. Catalog is `shareCatalogFromSnapshot` (capability `serverInstanceID` + snapshot assistant ids). Untargeted Android shares write a draft; `ShareRecipientPicker` assigns then delivers. iOS plugin exposes official `listPending`/`ack`/`releaseFiles` (aliases for `pending`/`acknowledge`). |
-| Push tap → session | landed | `sessionDeepLinkFromPushData` prefers `url`/`deeplink`, else `data.sessionId` → `openchamber://session/{id}`. iOS launch `remoteNotification` + `userNotificationCenter:didReceive`. Android intent extras + `FirebaseMessaging.getInitialMessage`. |
+| Push tap → session | landed | `sessionDeepLinkFromPushData` prefers `url`/`deeplink`, else `data.sessionId` → `openchamber://session/{id}`. iOS launch `remoteNotification` + `userNotificationCenter:didReceive`. Android `capturePushOpen` reads launch/new-intent extras (`url` / `deeplink` / `sessionId`). Native `FirebaseMessaging` has `token`, not FlutterFire `getInitialMessage()`. |
 | HTML preview render | landed (platform view) | `openchamber/html_preview_view`: WKWebView `loadHTMLString`, Android `WebView.loadDataWithBaseURL`. WidgetTester placeholder key `html-preview-platform`. Existing `html-preview-frame` ListView kept for sheet-dismiss. |
 
 Validated: focused Flutter analyze + `flutter test` on 3.32.8 (this agent). Session overflow / new-project stubs left for a later agent.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Status

**Superseded on `work/flutter-native` by `cb655f0d8`** (`fix(flutter): drop nonexistent Firebase getInitialMessage`), which landed while this branch was being pushed. Same compile fix: delete `readInitialFcmMessage()` / `FirebaseMessaging.getInitialMessage()`, keep `capturePushOpen` on launch/new-intent extras.

Do **not** merge this sibling — it only differs in comment/doc wording and would fight that tip. Flutter Mobile CI will rerun on `cb655f0d8`.

## Why (original)

Flutter Mobile CI **Android debug APK** failed on `d9e793ac1`:

```
Unresolved reference 'getInitialMessage'
```

`getInitialMessage()` is FlutterFire Dart, not native Firebase Android (`token` only).

## Change (this branch, now duplicate)

- Remove `readInitialFcmMessage()`.
- Keep cold-start / warm notification taps on `capturePushOpen(intent)`.
- Correct the gap-matrix wording.

No new pub dependencies. No golden / 1.18 / main merge. Not 真机过.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58c7f102-d574-4ce5-9869-0a49e10beaab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58c7f102-d574-4ce5-9869-0a49e10beaab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

