### PR TITLE
docs(flutter): point sideload at flutter-v2-debug-cb655f0

### DIFF
--- a/apps/mobile_flutter/README.md
+++ b/apps/mobile_flutter/README.md
@@ -63,7 +63,7 @@ Android uses the same timing/scale. Haptics are `performHapticFeedback` (CLOCK_T
 
 - Smoke (push to `work/flutter-native` only, plus `workflow_dispatch`): `.github/workflows/flutter-mobile-ci.yml`
   - `analyze-test` is the performance gate: `flutter test` includes `test/chat_transcript_perf_test.dart` (500-message fixture, rebuild-count + CI CPU budgets).
-  - Android job uploads `openchamber-flutter-android-debug-apk-<shortsha>` (14-day retention). The file inside is `openchamber-v2-debug-<shortsha>.apk` (`com.yee94.openchamber.debug`). Latest sideload prerelease: [`flutter-v2-debug-ec50d2b`](https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-ec50d2b) (official launcher icon).
+  - Android job uploads `openchamber-flutter-android-debug-apk-<shortsha>` (14-day retention). The file inside is `openchamber-v2-debug-<shortsha>.apk` (`com.yee94.openchamber.debug`). Latest sideload prerelease: [`flutter-v2-debug-cb655f0`](https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-cb655f0) (share drain + push tap + HTML WebView + official icon).
 - Signed release (`workflow_dispatch`, existing Capacitor secrets): `.github/workflows/flutter-mobile-release.yml`
 - No `integration_test` / `flutter drive` CI job. Linux has no phone GPU; macos-15 only compiles the simulator app. Local Timeline (not claimed 真机过):
 

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -216,10 +216,10 @@ What still keys off the **base** id / class namespace (not broken by the suffix)
 
 Preferred: the GitHub **prerelease** (no Actions Artifacts UI):
 
-- Tag `flutter-v2-debug-ec50d2b` (prerelease, not draft): https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-ec50d2b
-- APK: https://github.com/yee94/openchambery/releases/download/flutter-v2-debug-ec50d2b/openchamber-v2-debug-ec50d2b.apk
-- Built from `ec50d2ba9` / Flutter Mobile CI [run 33949263955](https://github.com/yee94/openchambery/actions/runs/33949263955) (analyze + Android debug APK + iOS simulator all green). Official OpenChamber launcher icon.
-- Includes voice UI removal + standard IME keyboard. Side-by-side `com.yee94.openchamber.debug` / **OpenChamber v2**. Relay-first walk — Yee has no LAN.
+- Tag `flutter-v2-debug-cb655f0` (prerelease, not draft): https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-cb655f0
+- APK: https://github.com/yee94/openchambery/releases/download/flutter-v2-debug-cb655f0/openchamber-v2-debug-cb655f0.apk
+- Built from `cb655f0d82bdabbdf9e43eaa6d5a645065f06521` / Flutter Mobile CI [run 33952157439](https://github.com/yee94/openchambery/actions/runs/33952157439) (#628 — analyze + Android debug APK + iOS simulator all green). Replaces older `flutter-v2-debug-3693287` / `flutter-v2-debug-ec50d2b` for sideload.
+- Tip includes share drain + push tap→session + HTML WebView preview + solid headers/scroll-safe plates + official launcher icon + Android `getInitialMessage` CI fix. Side-by-side `com.yee94.openchamber.debug` / **OpenChamber v2**. Relay-first walk — Yee has no LAN. Not 真机过.
 
 Actions artifact fallback (14-day retention):
 
@@ -611,7 +611,7 @@ Close automated gaps that do not need Yee's phone. Visual goldens / pixel chrome
 | Pairing v2 redeem | landed (memory + widget) | Parse-only-relay payload; `POST /api/client-auth/pairing/redeem`; Instances page shows `Connected · Relay` / `已连接 · 中继`. |
 | HEIC attach plumbing | landed (memory) | `prepareComposerAttachments` owns HEIC→JPEG + 25 MiB cap. Composer still publishes virtual assets. `sendPrompt` keeps official PUT headers + `file://` parts. |
 | OAuth callback URLs | landed (unit) | Query `code`/`state`/`error`; http(s)-only external browser. Live system-browser OAuth remains ❌ 真机过. |
-| Debug APK prerelease | published | `flutter-v2-debug-ec50d2b` from CI run 33949263955 / `ec50d2ba9` (official launcher icon). |
+| Debug APK prerelease | published | `flutter-v2-debug-cb655f0` from CI run 33952157439 / `cb655f0d8` (share drain + push tap + HTML WebView + solid headers + official icon + getInitialMessage CI fix). Replaces `3693287` / `ec50d2b`. |
 
 ## Seventeenth-slice status (main 1.19.5-beta.14 parity, no 真机过)
 
@@ -686,7 +686,7 @@ Closes the three code-gaps called out after the eighteenth slice. No merge to `m
 | Push tap → session | landed | `sessionDeepLinkFromPushData` prefers `url`/`deeplink`, else `data.sessionId` → `openchamber://session/{id}`. iOS launch `remoteNotification` + `userNotificationCenter:didReceive`. Android notification-tap extras via `capturePushOpen` (no FlutterFire `getInitialMessage`). |
 | HTML preview render | landed (platform view) | `openchamber/html_preview_view`: WKWebView `loadHTMLString`, Android `WebView.loadDataWithBaseURL`. WidgetTester placeholder key `html-preview-platform`. Existing `html-preview-frame` ListView kept for sheet-dismiss. |
 
-Validated: focused Flutter analyze + `flutter test` on 3.32.8 (this agent). Session overflow / new-project stubs left for a later agent.
+Validated: Flutter Mobile CI [#628](https://github.com/yee94/openchambery/actions/runs/33952157439) on `cb655f0d8` (analyze + Android debug APK + iOS simulator). Sideload prerelease: [`flutter-v2-debug-cb655f0`](https://github.com/yee94/openchambery/releases/tag/flutter-v2-debug-cb655f0). Session overflow / new-project stubs left for a later agent. Not 真机过.
 
 #### Will not port
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only pointer update so sideload instructions match the published Flutter v2 debug APK.

**Download (this is the deliverable):**
https://github.com/yee94/openchamber/releases/download/flutter-v2-debug-cb655f0/openchamber-v2-debug-cb655f0.apk

- Tag [`flutter-v2-debug-cb655f0`](https://github.com/yee94/openchamber/releases/tag/flutter-v2-debug-cb655f0) — prerelease, not draft
- SHA `cb655f0d82bdabbdf9e43eaa6d5a645065f06521` / Flutter Mobile CI [#628](https://github.com/yee94/openchamber/actions/runs/33952157439)
- Package `com.yee94.openchamber.debug` / label **OpenChamber v2**
- Replaces older `flutter-v2-debug-3693287` / `flutter-v2-debug-ec50d2b` for sideload
- Not 真机过. **Do not merge to `main`.** This PR targets `work/flutter-native` only.

No app/code change. The APK itself was uploaded from the existing green CI artifact; it was not rebuilt.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f1e0bd2-260b-4d1a-93cc-96b25f93feb1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f1e0bd2-260b-4d1a-93cc-96b25f93feb1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

