### PR TITLE
fix(flutter): drop unused overflow-test env so analyze is clean

### DIFF
--- a/apps/mobile_flutter/test/flutter_cap_overflow_test.dart
+++ b/apps/mobile_flutter/test/flutter_cap_overflow_test.dart
@@ -78,7 +78,7 @@ void main() {
   });
 
   testWidgets('chat overflow opens Cap Files / Changes / MCP / New session', (tester) async {
-    final env = await pumpApp(tester);
+    await pumpApp(tester);
     await tester.tap(find.byKey(const Key('home-session-sess-catalog')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('chat-more')));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Status

**Superseded on `work/flutter-native` by `b165d5cdf`** (`fix(flutter): drop unused overflow test env binding`), which landed while this branch was being pushed. Same one-line change: `await pumpApp(tester)` instead of unused `final env`.

Do **not** merge this sibling.

## Why (original)

Flutter Mobile CI **analyze + widget tests** failed on `0cd5bc9f` because `flutter analyze --no-fatal-infos` still fails on warnings:

```
unused_local_variable • test/flutter_cap_overflow_test.dart:81
```

## Validate (this branch, now duplicate)

- Local `flutter analyze --no-fatal-infos` on the package: only the pre-existing theme_tokens infos remain (exit 0).
- `flutter test test/flutter_cap_overflow_test.dart`: 8 passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58c7f102-d574-4ce5-9869-0a49e10beaab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58c7f102-d574-4ce5-9869-0a49e10beaab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

