### PR TITLE
fix(flutter): drop unused overflow-test env so analyze is green

### DIFF
--- a/apps/mobile_flutter/test/flutter_cap_overflow_test.dart
+++ b/apps/mobile_flutter/test/flutter_cap_overflow_test.dart
@@ -78,7 +78,7 @@ void main() {
   });
 
   testWidgets('chat overflow opens Cap Files / Changes / MCP / New session', (tester) async {
-    final env = await pumpApp(tester);
+    await pumpApp(tester);
     await tester.tap(find.byKey(const Key('home-session-sess-catalog')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('chat-more')));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Superseded. The same one-line unused `env` fix is already on `work/flutter-native` as `b165d5cdf` (`fix(flutter): drop unused overflow test env binding`). Flutter Mobile CI there is green: https://github.com/yee94/openchambery/actions/runs/33957376768

This PR’s **pr checks** job passed. The **review** job failed on `[@octokit/auth-app] appId option is required` — `OC_REVIEW_APP_ID` is unset in this workflow, not a code problem.

Base: `work/flutter-native`. Do not merge to `main`. This stacked branch can be dropped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da886148-5985-45b8-814b-f83c010b0065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da886148-5985-45b8-814b-f83c010b0065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

