### PR TITLE
feat(flutter): live client-diagnostics feat recorder

### DIFF
--- a/apps/mobile_flutter/lib/data/app_controller.dart
+++ b/apps/mobile_flutter/lib/data/app_controller.dart
@@ -20,7 +20,9 @@ import 'oauth.dart';
 import 'assistant_scheduled.dart';
 import 'chat_timeline.dart';
 import 'connection_candidates.dart';
+import 'app_version.dart';
 import 'context_usage.dart';
+import 'diagnostics_export.dart';
 import 'composer_autocomplete.dart';
 import 'composer_session_pick.dart';
 import 'git_commit_generate.dart';
@@ -101,6 +103,8 @@ class AppController extends ChangeNotifier {
   final Duration relayRaceHeadstart;
   final Future<void> Function(Duration duration)? relayRaceWait;
   bool _candidateRefreshInFlight = false;
+
+  bool diagnosticsEnabled = resolveTranscriptDiagnosticsEnabled(version: AppVersion.display);
 
   AppPhase phase = AppPhase.splash;
   ConnectForm connectForm = ConnectForm.welcome;
@@ -187,6 +191,11 @@ class AppController extends ChangeNotifier {
   Future<void> bootstrap({bool skipDelay = false}) async {
     locale = _localeFromCode(await _store.read(localeStorageKey));
     themeMode = _themeFromCode(await _store.read(themeStorageKey));
+    diagnosticsEnabled = resolveTranscriptDiagnosticsEnabled(
+      version: AppVersion.display,
+      preference: parseTranscriptDiagnosticsPreference(await _store.read(transcriptDiagnosticsPreferenceKey)),
+    );
+    clientDiagnosticsRecorder.setEnabled(diagnosticsEnabled);
     final snapshot = await _repository.load();
     _instances = await _hydrateTokens(snapshot.instances);
     _activeId = snapshot.activeId;
@@ -491,6 +500,13 @@ class AppController extends ChangeNotifier {
   Future<void> setThemeMode(ThemeMode next) async {
     themeMode = next;
     await _store.write(themeStorageKey, next.name);
+    notifyListeners();
+  }
+
+  Future<void> setDiagnosticsEnabled(bool enabled) async {
+    diagnosticsEnabled = enabled;
+    clientDiagnosticsRecorder.setEnabled(enabled);
+    await _store.write(transcriptDiagnosticsPreferenceKey, enabled ? 'true' : 'false');
     notifyListeners();
   }
 

--- a/apps/mobile_flutter/lib/data/chat_timeline.dart
+++ b/apps/mobile_flutter/lib/data/chat_timeline.dart
@@ -264,12 +264,15 @@ class ReverseChatController extends ChangeNotifier {
     _notifyStructure();
   }
 
-  void replaceAll(List<ChatMessage> messages) => applyMessages(messages);
+  void replaceAll(List<ChatMessage> messages) {
+    applyMessages(messages);
+  }
 
   /// Diff-apply a fetched transcript. Unchanged rows keep their [ValueNotifier]
   /// identity; only mutated ids notify their slot. Structure notifies only when
   /// ids or order change — not on every SSE token of the live tail.
-  void applyMessages(List<ChatMessage> messages) {
+  /// Returns whether ids or order changed (Cap skips unchanged SSE batches).
+  bool applyMessages(List<ChatMessage> messages) {
     var structureChanged = messages.length != _oldestFirst.length;
     if (!structureChanged) {
       for (var i = 0; i < messages.length; i += 1) {
@@ -302,6 +305,7 @@ class ReverseChatController extends ChangeNotifier {
       ..clear()
       ..addAll(next);
     if (structureChanged) _notifyStructure();
+    return structureChanged;
   }
 
   void _writeSlot(ChatMessage message) {

--- a/apps/mobile_flutter/lib/data/diagnostics_export.dart
+++ b/apps/mobile_flutter/lib/data/diagnostics_export.dart
@@ -1,6 +1,15 @@
 import 'dart:convert';
 
-/// Official Cap `openchamber.client-diagnostics.v1` export. No message bodies or tokens.
+import 'app_version.dart';
+import 'chat_timeline.dart';
+import 'openchamber_http.dart';
+
+/// Official Cap `openchamber.client-diagnostics.v1` keys and ring size.
+const transcriptDiagnosticsPreferenceKey = 'openchamber.client-diagnostics.enabled';
+const transcriptDiagnosticsLimit = 500;
+const transcriptDiagnosticsTailIds = 4;
+const _sensitiveError = r'bearer|token|authorization|password|secret|cookie';
+
 String diagnosticsExportFileName([DateTime? now]) {
   final stamp = (now ?? DateTime.now()).toUtc().toIso8601String().replaceAll(RegExp(r'[:.]'), '-');
   return 'openchamber-diagnostics-$stamp.json';
@@ -16,17 +25,245 @@ int diagnosticsExportEventCount(String content) {
   return 0;
 }
 
-String exportClientDiagnosticsReport({int exportedAt = 0, List<Map<String, Object?>> events = const []}) {
-  final feats = <String>{};
-  for (final event in events) {
-    final feat = event['feat']?.toString();
-    if (feat != null && feat.isNotEmpty) feats.add(feat);
+bool isPrereleaseClientVersion(String? version) => version != null && version.contains('-');
+
+bool? parseTranscriptDiagnosticsPreference(String? raw) {
+  if (raw == 'true') return true;
+  if (raw == 'false') return false;
+  return null;
+}
+
+bool resolveTranscriptDiagnosticsEnabled({String? version, bool? preference}) {
+  if (preference == true) return true;
+  if (preference == false) return false;
+  return isPrereleaseClientVersion(version);
+}
+
+String? sanitizeDiagnosticsError(Object? value) {
+  if (value == null) return null;
+  final text = value.toString().trim();
+  if (text.isEmpty) return null;
+  final clipped = text.length <= 240 ? text : text.substring(0, 240);
+  if (RegExp(_sensitiveError, caseSensitive: false).hasMatch(clipped)) return 'redacted-error';
+  return clipped;
+}
+
+int? diagnosticsHttpStatus(Object? error) {
+  if (error is OpenChamberHttpException && error.status >= 100 && error.status <= 599) {
+    return error.status;
   }
-  return const JsonEncoder.withIndent('  ').convert({
-    'schema': 'openchamber.client-diagnostics.v1',
-    'exportedAt': exportedAt == 0 ? DateTime.now().millisecondsSinceEpoch : exportedAt,
-    'eventCount': events.length,
-    'feats': feats.toList(),
-    'events': events,
+  return null;
+}
+
+List<String> lastTranscriptMessageIDs(List<ChatMessage> messages, {int limit = transcriptDiagnosticsTailIds}) {
+  if (messages.length <= limit) return [for (final message in messages) message.id];
+  return [for (final message in messages.sublist(messages.length - limit)) message.id];
+}
+
+int countIdentityMissingMessages(List<ChatMessage> messages) {
+  var missing = 0;
+  for (final message in messages) {
+    if (message.isUser) continue;
+    final agent = message.agentRole?.trim() ?? '';
+    final model = message.modelName?.trim() ?? '';
+    if (agent.isEmpty || model.isEmpty) missing += 1;
+  }
+  return missing;
+}
+
+int countFullParts(List<ChatMessage> messages) {
+  var count = 0;
+  for (final message in messages) {
+    count += message.parts.length;
+  }
+  return count;
+}
+
+class ClientDiagnosticsEvent {
+  const ClientDiagnosticsEvent({
+    required this.at,
+    required this.feat,
+    required this.kind,
+    required this.sessionID,
+    this.directory,
+    this.transport,
+    this.source,
+    this.requestStatus,
+    this.httpStatus,
+    this.messageCount,
+    this.lastMessageIDs,
+    this.slimPartCount,
+    this.fullPartCount,
+    this.identityMissingCount,
+    this.purpose,
+    this.error,
   });
+
+  final int at;
+  final String feat;
+  final String kind;
+  final String sessionID;
+  final String? directory;
+  final String? transport;
+  final String? source;
+  final String? requestStatus;
+  final int? httpStatus;
+  final int? messageCount;
+  final List<String>? lastMessageIDs;
+  final int? slimPartCount;
+  final int? fullPartCount;
+  final int? identityMissingCount;
+  final String? purpose;
+  final String? error;
+
+  Map<String, Object?> toJson() {
+    return {
+      'at': at,
+      'feat': feat,
+      'kind': kind,
+      'sessionID': sessionID,
+      if (directory != null && directory!.isNotEmpty) 'directory': directory,
+      if (transport != null && transport!.isNotEmpty) 'transport': transport,
+      if (source != null) 'source': source,
+      if (requestStatus != null) 'requestStatus': requestStatus,
+      if (httpStatus != null) 'httpStatus': httpStatus,
+      if (messageCount != null) 'messageCount': messageCount,
+      if (lastMessageIDs != null) 'lastMessageIDs': lastMessageIDs,
+      if (slimPartCount != null) 'slimPartCount': slimPartCount,
+      if (fullPartCount != null) 'fullPartCount': fullPartCount,
+      if (identityMissingCount != null) 'identityMissingCount': identityMissingCount,
+      if (purpose != null) 'purpose': purpose,
+      if (error != null) 'error': error,
+    };
+  }
+}
+
+ClientDiagnosticsEvent snapshotTranscriptDiagnostics({
+  required String kind,
+  required String sessionID,
+  String feat = 'transcript',
+  String? directory,
+  String? transport,
+  String? source,
+  String? requestStatus,
+  String? purpose,
+  Object? error,
+  List<ChatMessage>? messages,
+  int? now,
+}) {
+  return ClientDiagnosticsEvent(
+    at: now ?? DateTime.now().millisecondsSinceEpoch,
+    feat: feat,
+    kind: kind,
+    sessionID: sessionID,
+    directory: directory,
+    transport: transport,
+    source: source,
+    requestStatus: requestStatus,
+    httpStatus: diagnosticsHttpStatus(error),
+    messageCount: messages?.length,
+    lastMessageIDs: messages == null ? null : lastTranscriptMessageIDs(messages),
+    slimPartCount: messages == null ? null : 0,
+    fullPartCount: messages == null ? null : countFullParts(messages),
+    identityMissingCount: messages == null ? null : countIdentityMissingMessages(messages),
+    purpose: purpose,
+    error: sanitizeDiagnosticsError(error),
+  );
+}
+
+/// Official memory ring. Flutter has no IndexedDB; this is Cap's documented fallback.
+class ClientDiagnosticsRecorder {
+  ClientDiagnosticsRecorder({this.limit = transcriptDiagnosticsLimit, bool? enabled})
+      : _enabled = enabled ?? resolveTranscriptDiagnosticsEnabled(version: AppVersion.display);
+
+  final int limit;
+  bool _enabled;
+  final List<ClientDiagnosticsEvent> _events = [];
+
+  bool get isEnabled => _enabled;
+
+  void setEnabled(bool enabled) {
+    _enabled = enabled;
+  }
+
+  List<ClientDiagnosticsEvent> get events => List.unmodifiable(_events);
+
+  void record(ClientDiagnosticsEvent event) {
+    if (!_enabled) return;
+    _events.add(event);
+    if (_events.length > limit) {
+      _events.removeRange(0, _events.length - limit);
+    }
+  }
+
+  void recordSafely(ClientDiagnosticsEvent event) {
+    try {
+      record(event);
+    } catch (_) {}
+  }
+
+  void clear() => _events.clear();
+
+  String exportReport({int exportedAt = 0}) {
+    final feats = <String>{for (final event in _events) event.feat};
+    return const JsonEncoder.withIndent('  ').convert({
+      'schema': 'openchamber.client-diagnostics.v1',
+      'exportedAt': exportedAt == 0 ? DateTime.now().millisecondsSinceEpoch : exportedAt,
+      'eventCount': _events.length,
+      'feats': feats.toList(),
+      'events': [for (final event in _events) event.toJson()],
+    });
+  }
+}
+
+ClientDiagnosticsRecorder? _runtimeRecorder;
+
+ClientDiagnosticsRecorder get clientDiagnosticsRecorder {
+  return _runtimeRecorder ??= ClientDiagnosticsRecorder();
+}
+
+void debugResetClientDiagnosticsRecorder([ClientDiagnosticsRecorder? next]) {
+  _runtimeRecorder = next;
+}
+
+String exportClientDiagnosticsReport({int exportedAt = 0, List<Map<String, Object?>> events = const []}) {
+  if (events.isNotEmpty) {
+    return const JsonEncoder.withIndent('  ').convert({
+      'schema': 'openchamber.client-diagnostics.v1',
+      'exportedAt': exportedAt == 0 ? DateTime.now().millisecondsSinceEpoch : exportedAt,
+      'eventCount': events.length,
+      'feats': {
+        for (final event in events)
+          if (event['feat']?.toString().isNotEmpty == true) event['feat'].toString(),
+      }.toList(),
+      'events': events,
+    });
+  }
+  return clientDiagnosticsRecorder.exportReport(exportedAt: exportedAt);
+}
+
+void recordChatTranscriptDiagnostics({
+  required String kind,
+  required String sessionID,
+  String? directory,
+  String? transport,
+  String? source,
+  String? requestStatus,
+  String? purpose,
+  Object? error,
+  List<ChatMessage>? messages,
+}) {
+  clientDiagnosticsRecorder.recordSafely(
+    snapshotTranscriptDiagnostics(
+      kind: kind,
+      sessionID: sessionID,
+      directory: directory,
+      transport: transport,
+      source: source,
+      requestStatus: requestStatus,
+      purpose: purpose,
+      error: error,
+      messages: messages,
+    ),
+  );
 }

--- a/apps/mobile_flutter/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_flutter/lib/features/chat/chat_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../../data/app_controller.dart';
 import '../../data/chat_timeline.dart';
+import '../../data/diagnostics_export.dart';
 import '../../data/composer_session_pick.dart';
 import '../../data/context_usage.dart';
 import '../../data/home_session.dart';
@@ -161,11 +162,30 @@ class _ChatScreenState extends State<ChatScreen> {
       if (!mounted) return;
       // Diff-apply. Do not setState the page — slots update the live row.
       // Do not jumpTo: scrolled-up readers must not be yanked to the live edge.
-      _timeline.applyMessages(messages);
+      final structureChanged = _timeline.applyMessages(messages);
+      if (structureChanged) {
+        recordChatTranscriptDiagnostics(
+          kind: 'sse-event',
+          sessionID: _session.id,
+          directory: _session.directory,
+          transport: controller.liveEventTransport,
+          source: 'sse',
+          messages: messages,
+        );
+      }
       _contextTick.value += 1;
       _syncBusyFromController();
       unawaited(_refreshQuestions());
-    } on OpenChamberHttpException {
+    } on OpenChamberHttpException catch (error) {
+      recordChatTranscriptDiagnostics(
+        kind: 'request-error',
+        sessionID: _session.id,
+        directory: _session.directory,
+        source: 'sse',
+        requestStatus: 'error',
+        purpose: 'load-failed',
+        error: error,
+      );
       // Keep the last transcript; failure is not empty success.
     }
   }
@@ -180,6 +200,15 @@ class _ChatScreenState extends State<ChatScreen> {
       final messages = await controller.loadTranscript(_session);
       if (!mounted) return;
       _timeline.applyMessages(messages);
+      recordChatTranscriptDiagnostics(
+        kind: 'ensure-initial',
+        sessionID: _session.id,
+        directory: _session.directory,
+        transport: controller.liveEventTransport,
+        source: 'network',
+        purpose: 'ensure-initial',
+        messages: messages,
+      );
       _contextTick.value += 1;
       _errorKey.value = null;
       WidgetsBinding.instance.addPostFrameCallback((_) => _jumpToLatest());
@@ -192,8 +221,17 @@ class _ChatScreenState extends State<ChatScreen> {
       unawaited(_loadComposerCatalogs());
       unawaited(controller.remoteSettings.loadAgents());
       if (mounted) setState(() {});
-    } on OpenChamberHttpException {
+    } on OpenChamberHttpException catch (error) {
       if (!mounted) return;
+      recordChatTranscriptDiagnostics(
+        kind: 'request-error',
+        sessionID: _session.id,
+        directory: _session.directory,
+        source: 'network',
+        requestStatus: 'error',
+        purpose: 'load-failed',
+        error: error,
+      );
       _errorKey.value = 'chat.error.loadFailed';
     }
   }
@@ -427,7 +465,17 @@ class _ChatScreenState extends State<ChatScreen> {
       try {
         final messages = await controller.loadTranscript(_session);
         if (!mounted) return;
-        _timeline.applyMessages(messages);
+        final structureChanged = _timeline.applyMessages(messages);
+        if (structureChanged) {
+          recordChatTranscriptDiagnostics(
+            kind: 'refresh',
+            sessionID: _session.id,
+            directory: _session.directory,
+            source: 'network',
+            purpose: 'poll',
+            messages: messages,
+          );
+        }
         await controller.refreshSessionStatus(directory: _session.directory);
         _syncBusyFromController();
         if (!_busy.value || ticks >= 30) timer.cancel();

--- a/apps/mobile_flutter/lib/features/settings/settings_pages.dart
+++ b/apps/mobile_flutter/lib/features/settings/settings_pages.dart
@@ -406,21 +406,29 @@ class _AboutSettingsPageState extends State<AboutSettingsPage> {
           SettingsGroup(
             label: t(context, 'settings.openchamber.about.diagnostics.label'),
             children: [
-              ListTile(
-                title: Text(t(context, 'settings.openchamber.about.diagnostics.description')),
+              SettingsToggleRow(
+                key: const Key('about-diagnostics-enable'),
+                label: t(context, 'settings.openchamber.about.diagnostics.enable'),
+                subtitle: t(context, 'settings.openchamber.about.diagnostics.enableHint'),
+                value: widget.controller.diagnosticsEnabled,
+                onChanged: (enabled) async {
+                  await widget.controller.setDiagnosticsEnabled(enabled);
+                  if (mounted) setState(() {});
+                },
               ),
-              ListTile(
-                key: const Key('about-diagnostics-export'),
-                title: Text(
-                  t(
-                    context,
-                    _exporting
-                        ? 'settings.openchamber.about.diagnostics.exporting'
-                        : 'settings.openchamber.about.diagnostics.export',
+              if (widget.controller.diagnosticsEnabled)
+                ListTile(
+                  key: const Key('about-diagnostics-export'),
+                  title: Text(
+                    t(
+                      context,
+                      _exporting
+                          ? 'settings.openchamber.about.diagnostics.exporting'
+                          : 'settings.openchamber.about.diagnostics.export',
+                    ),
                   ),
+                  onTap: _exporting ? null : _exportDiagnostics,
                 ),
-                onTap: _exporting ? null : _exportDiagnostics,
-              ),
             ],
           ),
         ],

--- a/apps/mobile_flutter/lib/l10n/app_strings.dart
+++ b/apps/mobile_flutter/lib/l10n/app_strings.dart
@@ -553,6 +553,9 @@ class AppStrings {
     'settings.openchamber.about.diagnostics.description': 'Export local diagnostic feats for display and sync issues. No message bodies or tokens are included.',
     'settings.openchamber.about.diagnostics.export': 'Export log',
     'settings.openchamber.about.diagnostics.exporting': 'Exporting…',
+    'settings.openchamber.about.diagnostics.enable': 'Record diagnostic feats',
+    'settings.openchamber.about.diagnostics.enableHint':
+        'Available in beta builds. Records transcript sync and display lifecycle facts on this device.',
     'settings.openchamber.about.diagnostics.toast.exported': 'Diagnostics log exported',
     'settings.openchamber.about.diagnostics.toast.failed': 'Could not export diagnostics log',
     'settings.openchamber.about.diagnostics.toast.empty': 'Diagnostics log exported. No events were recorded yet.',
@@ -1195,6 +1198,8 @@ class AppStrings {
     'settings.openchamber.about.diagnostics.description': '导出本机诊断 feat，用于分析展示与同步问题。不包含消息正文或令牌。',
     'settings.openchamber.about.diagnostics.export': '导出日志',
     'settings.openchamber.about.diagnostics.exporting': '正在导出…',
+    'settings.openchamber.about.diagnostics.enable': '记录诊断 feat',
+    'settings.openchamber.about.diagnostics.enableHint': '仅测试版可用。在本机记录会话同步与展示生命周期，不含正文。',
     'settings.openchamber.about.diagnostics.toast.exported': '已导出诊断日志',
     'settings.openchamber.about.diagnostics.toast.failed': '无法导出诊断日志',
     'settings.openchamber.about.diagnostics.toast.empty': '已导出诊断日志。尚未记录任何事件。',

--- a/apps/mobile_flutter/test/flutter_diagnostics_recorder_test.dart
+++ b/apps/mobile_flutter/test/flutter_diagnostics_recorder_test.dart
@@ -1,0 +1,148 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openchamber/app.dart';
+import 'package:openchamber/data/app_controller.dart';
+import 'package:openchamber/data/app_version.dart';
+import 'package:openchamber/data/chat_timeline.dart';
+import 'package:openchamber/data/diagnostics_export.dart';
+import 'package:openchamber/data/openchamber_api.dart';
+import 'package:openchamber/data/openchamber_http.dart';
+import 'package:openchamber/data/secure_store.dart';
+import 'package:openchamber/features/chat/chat_screen.dart';
+import 'package:openchamber/features/shell/secondary_chrome.dart';
+import 'package:openchamber/native/platform_channels.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SecondaryChrome.debugReset();
+    debugResetClientDiagnosticsRecorder();
+  });
+
+  test('prerelease default is on; stable default is off; preference wins', () {
+    expect(isPrereleaseClientVersion(AppVersion.display), isTrue);
+    expect(resolveTranscriptDiagnosticsEnabled(version: AppVersion.display), isTrue);
+    expect(resolveTranscriptDiagnosticsEnabled(version: '1.19.5'), isFalse);
+    expect(resolveTranscriptDiagnosticsEnabled(version: '1.19.5', preference: true), isTrue);
+    expect(resolveTranscriptDiagnosticsEnabled(version: AppVersion.display, preference: false), isFalse);
+    expect(parseTranscriptDiagnosticsPreference('true'), isTrue);
+    expect(parseTranscriptDiagnosticsPreference('false'), isFalse);
+    expect(parseTranscriptDiagnosticsPreference(null), isNull);
+  });
+
+  test('recorder ring keeps 500 events and redacts tokens, never message bodies', () {
+    final recorder = ClientDiagnosticsRecorder(enabled: true);
+    debugResetClientDiagnosticsRecorder(recorder);
+    for (var i = 0; i < 502; i += 1) {
+      recorder.record(
+        snapshotTranscriptDiagnostics(
+          kind: 'ensure-initial',
+          sessionID: 'sess-$i',
+          now: 1700000000000 + i,
+          messages: [
+            ChatMessage(id: 'u$i', body: 'secret user body $i', isUser: true),
+            const ChatMessage(id: 'a1', body: 'assistant body', isUser: false),
+          ],
+        ),
+      );
+    }
+    expect(recorder.events.length, 500);
+    expect(recorder.events.first.sessionID, 'sess-2');
+    expect(recorder.events.last.sessionID, 'sess-501');
+    expect(sanitizeDiagnosticsError('Bearer abc.def'), 'redacted-error');
+    expect(sanitizeDiagnosticsError(const OpenChamberHttpException(503, '/api/session/x/messages')), contains('503'));
+    expect(diagnosticsHttpStatus(const OpenChamberHttpException(503, '/api/session/x/messages')), 503);
+
+    final content = recorder.exportReport(exportedAt: 1700000000000);
+    expect(content.contains('secret user body'), isFalse);
+    expect(content.contains('assistant body'), isFalse);
+    expect(content.contains('Bearer'), isFalse);
+    expect(content.contains('schema'), isTrue);
+    final parsed = jsonDecode(content) as Map<String, Object?>;
+    expect(parsed['schema'], 'openchamber.client-diagnostics.v1');
+    expect(parsed['eventCount'], 500);
+    expect(parsed['feats'], ['transcript']);
+    final first = (parsed['events'] as List).first as Map<String, Object?>;
+    expect(first['feat'], 'transcript');
+    expect(first['kind'], 'ensure-initial');
+    expect(first['lastMessageIDs'], ['u2', 'a1']);
+    expect(first['identityMissingCount'], 1);
+    expect(first.containsKey('body'), isFalse);
+  });
+
+  test('disabled recorder drops events', () {
+    final recorder = ClientDiagnosticsRecorder(enabled: false);
+    recorder.record(snapshotTranscriptDiagnostics(kind: 'ensure-initial', sessionID: 's'));
+    expect(recorder.events, isEmpty);
+    expect(diagnosticsExportEventCount(recorder.exportReport(exportedAt: 1)), 0);
+  });
+
+  testWidgets('chat load records ensure-initial without transcript text', (tester) async {
+    final transport = MemoryOpenChamberTransport();
+    final controller = AppController(store: MemorySecureStore(), api: OpenChamberApi(transport: transport));
+    await controller.bootstrap(skipDelay: true);
+    await controller.connect(url: 'http://192.168.1.74:2606');
+    await tester.pumpWidget(OpenChamberApp(controller: controller));
+    await tester.pumpAndSettle();
+    await controller.handleIncomingLink('openchamber://session/sess-catalog');
+    await tester.pumpAndSettle();
+    expect(find.byType(ChatScreen), findsOneWidget);
+    expect(clientDiagnosticsRecorder.events, isNotEmpty);
+    expect(clientDiagnosticsRecorder.events.first.kind, 'ensure-initial');
+    expect(clientDiagnosticsRecorder.events.first.source, 'network');
+    expect(clientDiagnosticsRecorder.events.first.lastMessageIDs, isNotEmpty);
+    final report = clientDiagnosticsRecorder.exportReport();
+    expect(report.contains('Open a session from Projects.'), isFalse);
+    expect(report.contains('oc_client'), isFalse);
+  });
+
+  testWidgets('chat load failure records request-error and keeps export official', (tester) async {
+    final transport = MemoryOpenChamberTransport()..messagesStatus = 503;
+    final controller = AppController(store: MemorySecureStore(), api: OpenChamberApi(transport: transport));
+    await controller.bootstrap(skipDelay: true);
+    await controller.connect(url: 'http://192.168.1.74:2606');
+    await tester.pumpWidget(OpenChamberApp(controller: controller));
+    await tester.pumpAndSettle();
+    await controller.handleIncomingLink('openchamber://session/sess-catalog');
+    await tester.pumpAndSettle();
+    expect(clientDiagnosticsRecorder.events.single.kind, 'request-error');
+    expect(clientDiagnosticsRecorder.events.single.purpose, 'load-failed');
+    expect(clientDiagnosticsRecorder.events.single.httpStatus, 503);
+    expect(clientDiagnosticsRecorder.events.single.error, isNot(contains('Bearer')));
+  });
+
+  testWidgets('About toggle hides export and persists the official preference key', (tester) async {
+    const channel = MethodChannel(OpenChamberChannels.media);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'saveFile') return {'cancelled': false};
+      return null;
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    });
+
+    final store = MemorySecureStore();
+    final controller = AppController(store: store, api: OpenChamberApi(transport: MemoryOpenChamberTransport()));
+    await controller.bootstrap(skipDelay: true);
+    await controller.connect(url: 'http://192.168.1.74:2606');
+    await tester.pumpWidget(OpenChamberApp(controller: controller));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('tab-settings')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const Key('settings-slug-about')));
+    await tester.tap(find.byKey(const Key('settings-slug-about')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(find.byKey(const Key('about-diagnostics-enable')), 120);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('about-diagnostics-export')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('about-diagnostics-enable')));
+    await tester.pumpAndSettle();
+    expect(controller.diagnosticsEnabled, isFalse);
+    expect(store.snapshot[transcriptDiagnosticsPreferenceKey], 'false');
+    expect(find.byKey(const Key('about-diagnostics-export')), findsNothing);
+  });
+}

--- a/apps/mobile_flutter/test/flutter_share_about_test.dart
+++ b/apps/mobile_flutter/test/flutter_share_about_test.dart
@@ -16,7 +16,10 @@ import 'package:openchamber/native/share_inbox.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(SecondaryChrome.debugReset);
+  setUp(() {
+    SecondaryChrome.debugReset();
+    debugResetClientDiagnosticsRecorder();
+  });
 
   test('Android share handoff geometry rejects oversized or non-image attachments', () {
     expect(usesAndroidShareComposerHandoff(platform: TargetPlatform.android), isTrue);
@@ -81,7 +84,8 @@ void main() {
     await tester.ensureVisible(find.byKey(const Key('settings-slug-about')));
     await tester.tap(find.byKey(const Key('settings-slug-about')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const Key('about-diagnostics-export')), findsOneWidget);
+    await tester.scrollUntilVisible(find.byKey(const Key('about-diagnostics-export')), 120);
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('about-diagnostics-export')));
     await tester.pumpAndSettle();
     expect(saved, isNotNull);

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -935,6 +935,40 @@ Live `wss://` relay pair + LAN hot-switch + iOS Local Network; HEIC/album; hoste
 
 Validated on Flutter **3.32.8 / Dart 3.8.1**: `flutter analyze --no-fatal-infos` (pre-existing `theme_tokens_test` infos only) + `flutter test` **295 passed**, including `flutter_share_about_test.dart` and `share_delivery_test.dart`. Screenshot PNGs were **not** recaptured (`07-chat*.png` rewritten by the screenshot test and reverted). Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
 
+## Thirty-first-slice status (2026-09-05) — live client-diagnostics feat recorder
+
+Stacked on `4748141f2` (`work/flutter-native` after the thirtieth share/about slice). Do **not** merge `main`. No 1.18 TanStack. No Flutter UI golden recapture. OpenChamber v2 `.debug` applicationId unchanged. Do **not** invent Flexoki, Finder, Capgo, plan/notes/Todo, Chat dock, `iosNativeUi`, Bonjour, Pierre, mermaid SVG, or Android launcher badge.
+
+Read on this checkout: Cap `transcript-diagnostics.ts` / `transcript-diagnostics-runtime.ts` (`openchamber.client-diagnostics.v1`, 500-event ring, preference `openchamber.client-diagnostics.enabled`, prerelease default on). Flutter has no IndexedDB — memory ring is the official fallback. Skip Capgo About beta-update rows. Skip invented transcript-diff / perf-window / task-click until those Flutter surfaces exist.
+
+### Landed this slice (code)
+
+| Surface | Official Cap mobile | Flutter | Notes |
+|---|---|---|---|
+| Feat recorder | IndexedDB or memory ring, 500 events | Memory ring, same schema / limit | No message bodies or tokens. User text stays out of load/refresh events (Cap puts it only on `transcript-diff` snapshots). |
+| Preference | `openchamber.client-diagnostics.enabled` | Same key via SecureStore | Prerelease default on; user override persists. |
+| About toggle | `SettingsToggleRow` + export only while on | Same official enable / enableHint / export keys | Export still uses `saveFile`. |
+| Chat record sites | `ensure-initial` / SSE skip-unchanged / `request-error` | `_load`, structure-changing live reload, poll, load failure | `message.part.delta` analogue: same-id token updates do not record. |
+
+### Still code / will-not-port
+
+| Gap | Why leftover |
+|---|---|
+| IndexedDB persistence / transcript-diff / task / perf feats | Cap WebView IndexedDB + TanStack/query-adapter diffs. Flutter records the load/SSE/error facts it actually has. |
+| Appearance Flexoki picker | **Do not invent.** Official **mobile** Appearance is language + Light/Dark/System. |
+| Finder | **Do not invent.** Cap `handleOpenInFinder` is desktop-only. |
+| Capgo / plan / notes / Todo / Chat dock / `iosNativeUi` / Bonjour / Pierre / mermaid SVG / Android launcher badge | Will not port. |
+
+### 真机-only
+
+Live `wss://` relay pair + LAN hot-switch + iOS Local Network; HEIC/album; hosted OAuth; ActivityKit / Dynamic Island / widget tap; Impeller 16ms; FCM on `.debug` if Firebase init fails; share-extension → inbox POST; system save-file picker on device. Code/plist may exist — do not fake 真机过.
+
+### EXHAUSTED
+
+**false.** Load/SSE/error feats and the About enable switch are landed. Residual CODE is richer Cap feats (transcript-diff / task / perf) plus 真机-only surfaces.
+
+Validated on Flutter **3.32.8 / Dart 3.8.1**: focused recorder tests + `flutter analyze --no-fatal-infos` + `flutter test`. Screenshot PNGs were **not** recaptured. Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
+
 
 
 ## Twenty-fourth-slice status (2026-09-05) — Cap phone overflow + composer no-ops

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -967,7 +967,7 @@ Live `wss://` relay pair + LAN hot-switch + iOS Local Network; HEIC/album; hoste
 
 **false.** Load/SSE/error feats and the About enable switch are landed. Residual CODE is richer Cap feats (transcript-diff / task / perf) plus 真机-only surfaces.
 
-Validated on Flutter **3.32.8 / Dart 3.8.1**: focused recorder tests + `flutter analyze --no-fatal-infos` + `flutter test`. Screenshot PNGs were **not** recaptured. Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
+Validated on Flutter **3.32.8 / Dart 3.8.1**: `flutter analyze --no-fatal-infos` (pre-existing `theme_tokens_test` infos only) + `flutter test` **301 passed**, including `flutter_diagnostics_recorder_test.dart` and `flutter_share_about_test.dart`. Screenshot PNGs were **not** recaptured (`07-chat*.png` rewritten by the screenshot test and reverted). Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
 
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Thirty-first Cap-mobile CODE slice, fast-forwardable onto `work/flutter-native` (`4748141f2`).

## What landed

**Official feat recorder**
- Cap `openchamber.client-diagnostics.v1` 500-event memory ring (Flutter has no IndexedDB; memory is the official fallback).
- Preference `openchamber.client-diagnostics.enabled` via SecureStore. Prerelease default on; user override persists.
- Chat `_load` records `ensure-initial` (`source: network`). Structure-changing live reloads record `sse-event`. Same-id token updates do not (Cap skips `message.part.delta` / unchanged SSE).
- Load failure records `request-error` with `purpose: load-failed` and sanitized `httpStatus`. No message bodies or tokens.

**About**
- Official enable / enableHint toggle. Export row only while recording is on.
- Export still uses native `saveFile`.

## Out of scope

- Cap IndexedDB persistence, `transcript-diff`, task-row/task-click, and perf-window feats (Flutter does not have those TanStack/query-adapter surfaces).
- 真机-only: live wss relay, LAN hot-switch, HEIC/album, hosted OAuth, ActivityKit, Impeller 16ms, FCM on `.debug`, share-extension → inbox POST, system save-file picker on device.
- Do not invent Flexoki / Finder / Capgo / plan / notes / Todo / Chat dock / `iosNativeUi` / Bonjour / Pierre / mermaid SVG / Android launcher badge.
- No 1.18 TanStack. No Flutter UI golden recapture.

## Validation

- `flutter analyze --no-fatal-infos` OK (pre-existing `theme_tokens_test` infos only).
- `flutter test` **301 passed**, including `flutter_diagnostics_recorder_test.dart` and `flutter_share_about_test.dart`.
- Screenshot PNGs were not recaptured (`07-chat*.png` rewritten by the screenshot test and reverted).
- Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80cd806e-7af3-4060-a910-dc04e644c7b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80cd806e-7af3-4060-a910-dc04e644c7b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

