### PR TITLE
feat(flutter): official transcript-diff on send, edit, and revert

### DIFF
--- a/apps/mobile_flutter/lib/data/diagnostics_export.dart
+++ b/apps/mobile_flutter/lib/data/diagnostics_export.dart
@@ -8,6 +8,7 @@ import 'openchamber_http.dart';
 const transcriptDiagnosticsPreferenceKey = 'openchamber.client-diagnostics.enabled';
 const transcriptDiagnosticsLimit = 500;
 const transcriptDiagnosticsTailIds = 4;
+const transcriptDiagnosticsUserTextLimit = 400;
 const _sensitiveError = r'bearer|token|authorization|password|secret|cookie';
 
 String diagnosticsExportFileName([DateTime? now]) {
@@ -71,6 +72,112 @@ int countIdentityMissingMessages(List<ChatMessage> messages) {
   return missing;
 }
 
+String? extractDiagnosticsUserText(ChatMessage message) {
+  if (!message.isUser) return null;
+  final joined = message.body.trim();
+  if (joined.isEmpty) return null;
+  if (RegExp(_sensitiveError, caseSensitive: false).hasMatch(joined)) return 'redacted-text';
+  if (joined.length <= transcriptDiagnosticsUserTextLimit) return joined;
+  return '${joined.substring(0, transcriptDiagnosticsUserTextLimit)}…';
+}
+
+Map<String, Object?> captureTranscriptCanonicalSnapshot(
+  List<ChatMessage> messages, {
+  Set<String> optimisticIds = const {},
+}) {
+  return {
+    'messageIDs': [for (final message in messages) message.id],
+    'messages': [
+      for (final message in messages)
+        {
+          'id': message.id,
+          'partCount': message.parts.length,
+          'slimCount': 0,
+          'fullCount': message.parts.length,
+          'optimistic': optimisticIds.contains(message.id),
+          'completed': message.completedClock != null && message.completedClock!.isNotEmpty,
+          'role': message.isUser ? 'user' : 'assistant',
+          if (extractDiagnosticsUserText(message) != null) 'text': extractDiagnosticsUserText(message),
+          if (!message.isUser &&
+              ((message.agentRole?.trim().isEmpty ?? true) || (message.modelName?.trim().isEmpty ?? true)))
+            'identityMissing': true,
+        },
+    ],
+  };
+}
+
+Map<String, Object?> diffTranscriptCanonicalSnapshots(
+  Map<String, Object?> before,
+  Map<String, Object?> after,
+) {
+  final beforeMessages = [
+    for (final item in (before['messages'] as List? ?? const []))
+      if (item is Map) item.map((key, value) => MapEntry(key.toString(), value)),
+  ];
+  final afterMessages = [
+    for (final item in (after['messages'] as List? ?? const []))
+      if (item is Map) item.map((key, value) => MapEntry(key.toString(), value)),
+  ];
+  final beforeById = {for (final message in beforeMessages) message['id']?.toString() ?? '': message};
+  final afterById = {for (final message in afterMessages) message['id']?.toString() ?? '': message};
+  final beforeIds = [for (final id in (before['messageIDs'] as List? ?? const [])) id.toString()];
+  final afterIds = [for (final id in (after['messageIDs'] as List? ?? const [])) id.toString()];
+  final beforeSet = beforeIds.toSet();
+  final afterSet = afterIds.toSet();
+  final partsChanged = <Map<String, Object?>>[];
+  final downgraded = <String>[];
+  final optimisticLost = <String>[];
+  final identityLost = <String>[];
+  for (final id in beforeIds) {
+    final previous = beforeById[id];
+    if (previous == null) continue;
+    final next = afterById[id];
+    if (next == null) {
+      if (previous['optimistic'] == true) optimisticLost.add(id);
+      continue;
+    }
+    if (previous['partCount'] != next['partCount'] ||
+        previous['slimCount'] != next['slimCount'] ||
+        previous['fullCount'] != next['fullCount'] ||
+        previous['optimistic'] != next['optimistic']) {
+      partsChanged.add({
+        'id': id,
+        'before': {
+          'partCount': previous['partCount'],
+          'slimCount': previous['slimCount'],
+          'fullCount': previous['fullCount'],
+          'optimistic': previous['optimistic'],
+        },
+        'after': {
+          'partCount': next['partCount'],
+          'slimCount': next['slimCount'],
+          'fullCount': next['fullCount'],
+          'optimistic': next['optimistic'],
+        },
+      });
+    }
+    if ((previous['fullCount'] as num? ?? 0) > 0 &&
+        (next['fullCount'] as num? ?? 0) == 0 &&
+        (next['slimCount'] as num? ?? 0) > 0) {
+      downgraded.add(id);
+    }
+    if (previous['optimistic'] == true && next['optimistic'] != true && next['completed'] != true) {
+      optimisticLost.add(id);
+    }
+    if (previous['identityMissing'] != true && next['identityMissing'] == true) {
+      identityLost.add(id);
+    }
+  }
+  return {
+    'addedMessageIDs': [for (final id in afterIds) if (!beforeSet.contains(id)) id],
+    'removedMessageIDs': [for (final id in beforeIds) if (!afterSet.contains(id)) id],
+    'partsChanged': partsChanged,
+    'downgraded': downgraded,
+    'optimisticLost': optimisticLost,
+    'identityLost': identityLost,
+  };
+}
+
 int countFullParts(List<ChatMessage> messages) {
   var count = 0;
   for (final message in messages) {
@@ -97,6 +204,10 @@ class ClientDiagnosticsEvent {
     this.identityMissingCount,
     this.purpose,
     this.error,
+    this.trigger,
+    this.before,
+    this.after,
+    this.diff,
   });
 
   final int at;
@@ -115,6 +226,10 @@ class ClientDiagnosticsEvent {
   final int? identityMissingCount;
   final String? purpose;
   final String? error;
+  final String? trigger;
+  final Map<String, Object?>? before;
+  final Map<String, Object?>? after;
+  final Map<String, Object?>? diff;
 
   Map<String, Object?> toJson() {
     return {
@@ -134,6 +249,10 @@ class ClientDiagnosticsEvent {
       if (identityMissingCount != null) 'identityMissingCount': identityMissingCount,
       if (purpose != null) 'purpose': purpose,
       if (error != null) 'error': error,
+      if (trigger != null) 'trigger': trigger,
+      if (before != null) 'before': before,
+      if (after != null) 'after': after,
+      if (diff != null) 'diff': diff,
     };
   }
 }
@@ -266,4 +385,36 @@ void recordChatTranscriptDiagnostics({
       messages: messages,
     ),
   );
+}
+
+void recordTranscriptDiff({
+  required String trigger,
+  required String sessionID,
+  required List<ChatMessage> before,
+  required List<ChatMessage> after,
+  String? directory,
+  String? transport,
+  String? purpose,
+  Set<String> optimisticAfterIds = const {},
+  int? now,
+}) {
+  try {
+    final beforeSnap = captureTranscriptCanonicalSnapshot(before);
+    final afterSnap = captureTranscriptCanonicalSnapshot(after, optimisticIds: optimisticAfterIds);
+    clientDiagnosticsRecorder.record(
+      ClientDiagnosticsEvent(
+        at: now ?? DateTime.now().millisecondsSinceEpoch,
+        feat: 'transcript',
+        kind: 'transcript-diff',
+        sessionID: sessionID,
+        directory: directory,
+        transport: transport,
+        purpose: purpose,
+        trigger: trigger,
+        before: beforeSnap,
+        after: afterSnap,
+        diff: diffTranscriptCanonicalSnapshots(beforeSnap, afterSnap),
+      ),
+    );
+  } catch (_) {}
 }

--- a/apps/mobile_flutter/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_flutter/lib/features/chat/chat_screen.dart
@@ -406,8 +406,19 @@ class _ChatScreenState extends State<ChatScreen> {
       }
     }
     final messageId = ascendingId('msg');
+    final beforeSend = _timeline.oldestFirst;
+    final editId = _editingMessageId;
     _timeline.appendNewer(
       ChatMessage(id: messageId, body: body.isEmpty ? pending.map((item) => item.name).join(', ') : body, isUser: true),
+    );
+    recordTranscriptDiff(
+      trigger: editId != null ? 'user-edit' : 'user-send',
+      sessionID: _session.id,
+      directory: _session.directory,
+      transport: controller?.liveEventTransport,
+      before: beforeSend,
+      after: _timeline.oldestFirst,
+      optimisticAfterIds: {messageId},
     );
     _composer.clear();
     setState(() => _attachments.clear());
@@ -420,7 +431,6 @@ class _ChatScreenState extends State<ChatScreen> {
       return;
     }
     try {
-      final editId = _editingMessageId;
       if (editId != null) {
         await controller.revertSession(session: _session, messageId: editId);
         _editingMessageId = null;
@@ -523,9 +533,13 @@ class _ChatScreenState extends State<ChatScreen> {
           }
         }
         if (target == null) return true;
+        final before = _timeline.oldestFirst;
         final ok = await controller.revertSession(session: _session, messageId: target.id);
         if (!ok && mounted) _errorKey.value = controller.lastMutationErrorKey ?? 'chat.messageBody.actions.revertFailed';
-        if (ok) await _reloadFromLive();
+        if (ok) {
+          await _reloadFromLive();
+          _recordUserDeleteDiff(before);
+        }
         return true;
       case 'redo':
         final restored = await controller.unrevertSession(session: _session);
@@ -686,6 +700,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Future<void> _revertMessage(ChatMessage message) async {
     final controller = widget.appController;
     if (controller == null) return;
+    final before = _timeline.oldestFirst;
     final ok = await controller.revertSession(session: _session, messageId: message.id);
     if (!mounted) return;
     if (!ok) {
@@ -696,6 +711,18 @@ class _ChatScreenState extends State<ChatScreen> {
       return;
     }
     await _reloadFromLive();
+    _recordUserDeleteDiff(before);
+  }
+
+  void _recordUserDeleteDiff(List<ChatMessage> before) {
+    recordTranscriptDiff(
+      trigger: 'user-delete',
+      sessionID: _session.id,
+      directory: _session.directory,
+      transport: widget.appController?.liveEventTransport,
+      before: before,
+      after: _timeline.oldestFirst,
+    );
   }
 
   void _editMessage(ChatMessage message) {

--- a/apps/mobile_flutter/test/flutter_diagnostics_recorder_test.dart
+++ b/apps/mobile_flutter/test/flutter_diagnostics_recorder_test.dart
@@ -145,4 +145,60 @@ void main() {
     expect(store.snapshot[transcriptDiagnosticsPreferenceKey], 'false');
     expect(find.byKey(const Key('about-diagnostics-export')), findsNothing);
   });
+
+  test('transcript-diff snapshots keep bounded user text and never assistant bodies', () {
+    const before = [
+      ChatMessage(id: 'm1', body: 'hello token bearer secret', isUser: true),
+      ChatMessage(id: 'a1', body: 'assistant should stay out', isUser: false, modelName: 'sonnet', agentRole: 'build'),
+    ];
+    const after = [
+      ...before,
+      ChatMessage(id: 'm2', body: 'follow up', isUser: true),
+    ];
+    final beforeSnap = captureTranscriptCanonicalSnapshot(before);
+    final afterSnap = captureTranscriptCanonicalSnapshot(after, optimisticIds: {'m2'});
+    final diff = diffTranscriptCanonicalSnapshots(beforeSnap, afterSnap);
+    expect(diff['addedMessageIDs'], ['m2']);
+    expect((beforeSnap['messages'] as List).first, containsPair('text', 'redacted-text'));
+    expect(jsonEncode(afterSnap).contains('assistant should stay out'), isFalse);
+    recordTranscriptDiff(
+      trigger: 'user-send',
+      sessionID: 'sess-1',
+      before: before,
+      after: after,
+      optimisticAfterIds: {'m2'},
+      now: 1700000000000,
+    );
+    final event = clientDiagnosticsRecorder.events.single;
+    expect(event.kind, 'transcript-diff');
+    expect(event.trigger, 'user-send');
+    expect(event.diff?['addedMessageIDs'], ['m2']);
+    expect(event.exportJsonHasAssistantBody, isFalse);
+  });
+
+  testWidgets('composer send records user-send transcript-diff without assistant text', (tester) async {
+    final controller = AppController(store: MemorySecureStore(), api: OpenChamberApi(transport: MemoryOpenChamberTransport()));
+    await controller.bootstrap(skipDelay: true);
+    await controller.connect(url: 'http://192.168.1.74:2606');
+    await tester.pumpWidget(OpenChamberApp(controller: controller));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('home-session-sess-catalog')));
+    await tester.pumpAndSettle();
+    clientDiagnosticsRecorder.clear();
+    await tester.enterText(find.byKey(const Key('composer-field')), 'from flutter send');
+    await tester.tap(find.byKey(const Key('composer-send')));
+    await tester.pumpAndSettle();
+    final diffs = clientDiagnosticsRecorder.events.where((event) => event.kind == 'transcript-diff').toList();
+    expect(diffs, isNotEmpty);
+    expect(diffs.first.trigger, 'user-send');
+    expect(diffs.first.diff?['addedMessageIDs'], isNotEmpty);
+    final report = clientDiagnosticsRecorder.exportReport();
+    expect(report.contains('from flutter send'), isTrue);
+    expect(report.contains('This list is a reverse LegendList analogue'), isFalse);
+    expect(report.contains('oc_client'), isFalse);
+  });
+}
+
+extension on ClientDiagnosticsEvent {
+  bool get exportJsonHasAssistantBody => jsonEncode(toJson()).contains('assistant should stay out');
 }

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -998,7 +998,7 @@ Live `wss://` relay pair + LAN hot-switch + iOS Local Network; HEIC/album; hoste
 
 **false.** `transcript-diff` on the Flutter mutation surfaces is landed. Residual CODE is task/perf feats plus 真机-only surfaces.
 
-Validated on Flutter **3.32.8 / Dart 3.8.1**: focused recorder tests + `flutter analyze --no-fatal-infos` + `flutter test`. Screenshot PNGs were **not** recaptured. Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
+Validated on Flutter **3.32.8 / Dart 3.8.1**: `flutter analyze --no-fatal-infos` (pre-existing `theme_tokens_test` infos only) + `flutter test` **303 passed**, including `flutter_diagnostics_recorder_test.dart`. Screenshot PNGs were **not** recaptured (`07-chat*.png` rewritten by the screenshot test and reverted). Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
 
 
 

--- a/docs/flutter-native-gap.md
+++ b/docs/flutter-native-gap.md
@@ -969,6 +969,37 @@ Live `wss://` relay pair + LAN hot-switch + iOS Local Network; HEIC/album; hoste
 
 Validated on Flutter **3.32.8 / Dart 3.8.1**: `flutter analyze --no-fatal-infos` (pre-existing `theme_tokens_test` infos only) + `flutter test` **301 passed**, including `flutter_diagnostics_recorder_test.dart` and `flutter_share_about_test.dart`. Screenshot PNGs were **not** recaptured (`07-chat*.png` rewritten by the screenshot test and reverted). Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
 
+## Thirty-second-slice status (2026-09-05) — official transcript-diff on send / edit / revert
+
+Stacked on `d58a12dba` (`work/flutter-native` after the thirty-first recorder slice). Do **not** merge `main`. No 1.18 TanStack. No Flutter UI golden recapture. OpenChamber v2 `.debug` applicationId unchanged. Do **not** invent Flexoki, Finder, Capgo, plan/notes/Todo, Chat dock, `iosNativeUi`, Bonjour, Pierre, mermaid SVG, or Android launcher badge.
+
+Read on this checkout: Cap `snapshotTranscriptDiff` / `captureTranscriptCanonicalSnapshot` (`user-send` / `user-edit` / `user-delete`). Flutter send, edit-send, overflow revert, and `/undo` are the matching mutation surfaces. Skip task-row / task-click / perf-window (no TanStack query-adapter or 30s JS probe). Skip Capgo About rows.
+
+### Landed this slice (code)
+
+| Surface | Official Cap mobile | Flutter | Notes |
+|---|---|---|---|
+| `transcript-diff` | before/after IDs + part counts + bounded user text | Same event shape on send / edit / revert | Assistant bodies stay out. Credential-shaped user text is `redacted-text`. Optimistic flag is only the just-appended send id. |
+| `/undo` + overflow revert | `user-delete` | Same trigger after reload | Failed revert does not record a fake success diff. |
+
+### Still code / will-not-port
+
+| Gap | Why leftover |
+|---|---|
+| task-row / task-click / perf-window | Cap Task lifecycle + 30s JS probe. Flutter task cards do not own child-session navigate facts or Impeller counters. |
+| IndexedDB persistence | Official fallback is the memory ring. |
+| Appearance Flexoki picker / Finder / Capgo / plan / notes / Todo / Chat dock / `iosNativeUi` / Bonjour / Pierre / mermaid SVG / Android launcher badge | Will not port. |
+
+### 真机-only
+
+Live `wss://` relay pair + LAN hot-switch + iOS Local Network; HEIC/album; hosted OAuth; ActivityKit / Dynamic Island / widget tap; Impeller 16ms; FCM on `.debug` if Firebase init fails; share-extension → inbox POST; system save-file picker on device. Code/plist may exist — do not fake 真机过.
+
+### EXHAUSTED
+
+**false.** `transcript-diff` on the Flutter mutation surfaces is landed. Residual CODE is task/perf feats plus 真机-only surfaces.
+
+Validated on Flutter **3.32.8 / Dart 3.8.1**: focused recorder tests + `flutter analyze --no-fatal-infos` + `flutter test`. Screenshot PNGs were **not** recaptured. Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.
+
 
 
 ## Twenty-fourth-slice status (2026-09-05) — Cap phone overflow + composer no-ops


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Thirty-second Cap-mobile CODE slice, fast-forwardable onto `work/flutter-native` (`d58a12dba`).

## What landed

Official `transcript-diff` events on Flutter's existing mutation surfaces:

- Composer send → `user-send`
- Edit-then-send → `user-edit`
- Overflow revert and `/undo` → `user-delete` after a successful reload

Snapshots keep message IDs, part counts, identity-missing flags, and bounded user text (400 chars; credential-shaped values become `redacted-text`). Assistant bodies and tokens stay out. The just-appended send id is the only optimistic row.

## Out of scope

- task-row / task-click / perf-window (Cap Task lifecycle + 30s JS probe)
- IndexedDB persistence (memory ring remains the official fallback)
- 真机-only surfaces
- Do not invent Flexoki / Finder / Capgo / plan / notes / Todo / Chat dock / `iosNativeUi` / Bonjour / Pierre / mermaid SVG / Android launcher badge
- No 1.18 TanStack. No Flutter UI golden recapture.

## Validation

- `flutter analyze --no-fatal-infos` OK (pre-existing `theme_tokens_test` infos only).
- `flutter test` **303 passed**, including `flutter_diagnostics_recorder_test.dart`.
- Screenshot PNGs were not recaptured (`07-chat*.png` rewritten by the screenshot test and reverted).
- Not 真机过. Flutter Mobile CI is push-only on `work/flutter-native`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80cd806e-7af3-4060-a910-dc04e644c7b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80cd806e-7af3-4060-a910-dc04e644c7b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

