### PR TITLE
feat(lynx): connect / pairing v2 / instance persistence kernel

### DIFF
--- a/docs/lynx-gap-board.md
+++ b/docs/lynx-gap-board.md
@@ -19,10 +19,17 @@ Lynx app skeleton **does not exist**. This board is seeded honestly from `docs/l
 
 | Item | Notes |
 |---|---|
-| Branch `work/lynx-native` from `b444b0316` | Docs gate only |
+| Branch `work/lynx-native` from `b444b0316` | Docs gate + connect kernel |
 | This documentation set | `docs/lynx-feature-inventory.md`, `docs/lynx-pitfalls.md`, `docs/lynx-gap-board.md`, `docs/lynx-acceptance.md`, `docs/lynx-ia-ui.md` |
+| Connect kernel (`@openchamber/lynx`) | `packages/lynx` — host-agnostic. Official `GET /health`, `GET/POST /auth/session`, `POST /api/client-auth/pairing/redeem`, `GET /api/client-auth/connection/candidates`. No demo hosts. |
+| Instance persist (full LAN+relay v2 set) | Metadata JSON + secure-store adapter. `relayUrl` + `hostEncPubJwk` round-trip. Tokens never written to metadata and never logged. |
+| Pairing-link / QR **parse** + redeem v2 | Same `p=` payload as Cap. Redeem only on a reachable transport. No invented `/api/nearby/redeem`. |
+| `openchamber://` parse + apply inbox | Same intent union as `packages/ui/src/apps/deepLinks.ts`. Pairing can run on welcome; other intents stash until `setReady`. |
+| Connect race harness | Relay-only skips the 1.5s LAN headstart. Unit tests in `@openchamber/lynx`. |
 
-Nothing else is landed. There is no Lynx package, no host app, no CI workflow, no list, no connect screen.
+**Host still missing.** The Lynx iOS/Android app package, splash/welcome **view**, Keychain/Keystore plugin, and camera scanner are not in tree. The kernel is the integration point: `createLynxConnectionController(hostAdapters)`.
+
+CI绿 for this slice is the Lynx unit project only. There is still no Lynx APK / iOS-simulator job. 真机过: not executed (environment: Linux cloud agent; no Xcode/adb).
 
 ---
 
@@ -35,11 +42,9 @@ Seeded from the inventory. Grouped so a slice can pick a coherent vertical.
 | Item | Cap/web source | Lynx note |
 |---|---|---|
 | Lynx app package (iOS + Android) | `packages/mobile` | New tree; do not wrap WKWebView |
-| Connect / splash while auto-connect resolves | `MobileApp.tsx` welcome | Real `GET /health` + session |
-| Instance list, add, delete, password unlock | `mobileConnections.ts` | Persist **full** LAN+relay candidate set |
-| QR + pairing-link redeem v2 | `mobileQrScan.ts` | No invented redeem API |
-| `openchamber://` parse + apply | `deepLinks.ts` | Same intent union |
-| Secure store (Keychain / Keystore) | Capacitor secure storage | Never log tokens |
+| Connect / splash **view** | `MobileApp.tsx` welcome | Kernel `phase: resolving \| welcome` is landed. **Stub:** no Lynx page draws the splash yet. |
+| QR **camera** | `mobileQrScan.ts` | Parse + redeem landed. **Stub:** `scanQr` host adapter (no camera plugin). |
+| Secure store **native plugin** | Capacitor secure storage | Adapter + tests landed. **Stub:** Keychain/Keystore binding is host work. |
 | Four-tab dock | `mobileTabs.ts` | Chat is **pushed**, not a tab |
 | Host Tab/Nav embedding decision | README § tab bar | See `docs/lynx-ia-ui.md` — do not auto-skin twice |
 
@@ -132,8 +137,8 @@ Glass-container fusion (`spacing`, `glass-interactive`, `glass-tint-color`) is *
 
 First implementation slice after this doc gate (order is deliberate: connect → shell → list engine → one real transcript).
 
-1. **Host app skeleton** (iOS + Android) that can load a Lynx page. Decide embedding (`docs/lynx-ia-ui.md`) **before** drawing a dock.
-2. **Connect + instance persistence** against a real server (LAN candidate, then relay). No demo hosts.
+1. **Host app skeleton** (iOS + Android) that can load a Lynx page. Decide embedding (`docs/lynx-ia-ui.md`) **before** drawing a dock. Bind `packages/lynx` connect adapters (HTTP, Keychain/Keystore, optional QR camera, official relay tunnel).
+2. **Connect + instance persistence** — kernel landed in `@openchamber/lynx` (official health/session/redeem). Remaining: host splash/welcome view + native secure store + camera + 真机.
 3. **Four-tab shell** with chat as a pushed page. System Tab/Nav if host-owned; Lynx dock only if Lynx owns chrome.
 4. **Projects home** from session-index (failure ≠ empty).
 5. **LegendList-semantics chat list** + send/stop on official APIs. This is the quality gate; do not prototype TanStack-style split lists “just to see pixels”.
@@ -146,7 +151,11 @@ Do not start Share / Live Activity / widgets / Capgo / voice invention in slice 
 
 ## 真机残差
 
-Empty until something is claimed landed. Seed the **kinds** of residual this track must expect (from Cap + Flutter history):
+| Item | Notes |
+|---|---|
+| Connect 真机过 | **not executed** (environment: Linux cloud agent; no Xcode, no adb, no physical device). Kernel is unit-tested only. |
+
+Seed the **kinds** of residual this track must expect (from Cap + Flutter history):
 
 | Residual class | Why it will show up |
 |---|---|
@@ -192,7 +201,7 @@ A row moves here only after 代码接上 + CI绿 and a **written** device log (d
 
 | Slug | Status | First honest body |
 |---|---|---|
-| `instances` | missing | List + add + QR; persist v2 `relayUrl` |
+| `instances` | missing | Persist contract is in `@openchamber/lynx` (list/add/delete/QR redeem). Settings **page** not drawn. |
 | `appearance` | missing | Language + theme (`flexoki-*` ids). No `iosNativeUi` toggle |
 | `chat` | missing | Real GET/PUT `/api/config/settings` chat fields |
 | `notifications` | missing | Toggles + APNs/FCM register |

--- a/knip.json
+++ b/knip.json
@@ -65,6 +65,14 @@
         "scripts/**/*.{js,cjs,mjs}"
       ]
     },
+    "packages/lynx": {
+      "entry": [
+        "src/**/*.{test,spec}.ts"
+      ],
+      "project": [
+        "src/**/*.ts"
+      ]
+    },
     "packages/vscode": {
       "entry": [
         "src/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}",

--- a/packages/lynx/README.md
+++ b/packages/lynx/README.md
@@ -1,0 +1,35 @@
+# `@openchamber/lynx`
+
+Lynx-track modules for the independent `work/lynx-native` rewrite. **Do not merge to `main`.**
+
+There is no Lynx host app in this repository yet. This package is the import path the future iOS/Android shell should call.
+
+## Connect kernel
+
+```ts
+import { createLynxConnectionController } from '@openchamber/lynx/connect';
+```
+
+See `src/connect/DOCUMENTATION.md` for the official API map, persistence keys, and host adapter contracts.
+
+What this package does:
+
+- Splash/auto-connect against real `GET /health` + `GET /auth/session`
+- Instance list add / delete / password unlock
+- Persist the full LAN + relay candidate set (`relayUrl` + `hostEncPubJwk`)
+- Pairing v2 QR / paste / `openchamber://connect?v=2&p=…` redeem on `POST /api/client-auth/pairing/redeem`
+- Same deep-link intent union as Capacitor `deepLinks.ts`
+- Secure-store adapter for tokens (never logged)
+
+What this package does **not** do:
+
+- Bonjour / Nearby / LAN browse
+- Invented redeem or ASR/voice
+- Draw a Lynx splash page (kernel exposes `phase` + `autoConnectLabel`; the host view is still missing)
+- Bind Keychain/Keystore or a camera (host adapters; labeled stubs)
+
+## Test
+
+```sh
+bunx vitest run --project @openchamber/lynx
+```

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openchamber/lynx",
+  "version": "1.19.7-beta.7",
+  "private": true,
+  "type": "module",
+  "description": "Lynx-track connect, pairing, and instance modules. No host app yet — the shell imports this kernel.",
+  "exports": {
+    ".": "./src/index.ts",
+    "./connect": "./src/connect/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint \"./src/**/*.ts\" --config ../../eslint.config.js",
+    "build": "tsc --noEmit"
+  }
+}

--- a/packages/lynx/src/connect/DOCUMENTATION.md
+++ b/packages/lynx/src/connect/DOCUMENTATION.md
@@ -1,0 +1,57 @@
+# Lynx connect kernel
+
+Host-agnostic TypeScript for the Lynx track. The Lynx iOS/Android app package is **not** in tree yet. A future shell imports this module and injects host adapters.
+
+```ts
+import { createLynxConnectionController } from '@openchamber/lynx/connect';
+
+const controller = createLynxConnectionController({
+  request,          // native GET/POST to a LAN or tunnel URL
+  openRelay,        // official E2EE tunnel; then the same HTTP paths
+  secureStore,      // Keychain / Keystore
+  metadataStore,    // instance list without tokens
+  bindRuntime,      // switch the shell's active origin + bearer
+  scanQr,           // optional camera; kernel only parses
+});
+
+await controller.resolveLaunch(); // splash while auto-connect runs
+```
+
+There is **no Nearby / Bonjour / mDNS**. Discovery is QR, paste of `openchamber://connect?v=2&p=…`, or a typed URL.
+
+## Official API map
+
+| Action | Route | Notes |
+|---|---|---|
+| Reachability | `GET /health` | No bearer. Optional `serverId` must match a paired relay identity. |
+| Session probe | `GET /auth/session` | Bearer when we have a token. `401` / `authenticated:false` → password unlock. |
+| Password unlock | `POST /auth/session` | `{ password, trustDevice, issueClientToken, clientKind: 'mobile', dedupeKey }` |
+| Pairing redeem v2 | `POST /api/client-auth/pairing/redeem` | `{ pairingId, secret, clientKind: 'mobile', dedupeKey }`. One-shot; do not retry other candidates. |
+| Refresh LAN set | `GET /api/client-auth/connection/candidates` | After bind. Echoed `serverId` required. |
+
+Do **not** invent `/api/nearby/redeem` or any other redeem URL. Relay redeem uses the same path over the host tunnel.
+
+## Persistence
+
+- Metadata (`id`, `label`, ordered `candidates`, `hasToken`, `lastUsedAt`) — JSON store. Cap key: `openchamber.mobile.connections.v1`.
+- Token — secure store only, key `openchamber.mobile.token.<urlencoded runtime key>`.
+- Runtime key is `relay:<serverId>@<relayUrl>` when a relay candidate exists, else the normalized LAN URL.
+- A pairing payload persists **every** LAN + relay candidate, including `relayUrl` + `hostEncPubJwk`. Grant is never stored.
+
+## Connect race
+
+LAN candidates start immediately. Relay starts after 1.5s **or** as soon as every LAN candidate is unreachable. A **relay-only** payload does not sleep.
+
+## Deep links
+
+Same intent union as `packages/ui/src/apps/deepLinks.ts`. Pairing can run on the welcome screen. Other intents stash until `setReady(true)`.
+
+## Host stubs (labeled)
+
+| Adapter | Status |
+|---|---|
+| `request` / probe / redeem / password | Kernel landed. Host supplies native HTTP. |
+| `openRelay` | Kernel treats relay as a transport. Host must bind the official tunnel client. |
+| `secureStore` | Contract landed. Keychain/Keystore plugin is host work. |
+| `scanQr` | Parse + redeem landed. Camera is host work. |
+| Splash / welcome Lynx page | Kernel exposes `phase` / `autoConnectLabel`. No Lynx view yet. |

--- a/packages/lynx/src/connect/applyDeepLink.ts
+++ b/packages/lynx/src/connect/applyDeepLink.ts
@@ -1,0 +1,124 @@
+/**
+ * Apply `openchamber://` intents the same way Cap's `deepLinkNavigation` does:
+ * pairing v2 redeem can run on the disconnected welcome screen; navigation
+ * intents stash until the shell is ready.
+ */
+
+import { parseDeepLink } from './deepLinks.ts';
+import type { LynxDeepLinkIntent, LynxPairingConnectionPayload, LynxSessionsFilter } from './types.ts';
+
+export type LynxDeepLinkHandlers = {
+  openSessions?: (filter?: LynxSessionsFilter) => void;
+  openView?: (target: 'files' | 'mcp' | 'instances' | 'update') => void;
+  openChanges?: (options?: { path?: string; staged?: boolean }) => void;
+  openSettings?: (section?: string) => void;
+  openSession?: (sessionId: string, directory?: string) => void;
+  openDraft?: (intent: Extract<LynxDeepLinkIntent, { type: 'new-session' }>) => void;
+  openProject?: (directory: string) => void;
+  openStatus?: () => void;
+};
+
+export type LynxApplyDeepLinkResult =
+  | { kind: 'ignored' }
+  | { kind: 'pairing-queued'; pairing: LynxPairingConnectionPayload }
+  | { kind: 'pairing-started'; pairing: LynxPairingConnectionPayload }
+  | { kind: 'navigation'; intent: Exclude<LynxDeepLinkIntent, { type: 'connect' }> }
+  | { kind: 'stashed'; intent: LynxDeepLinkIntent };
+
+export type LynxDeepLinkInbox = {
+  applyUrl: (raw: string | null | undefined) => LynxApplyDeepLinkResult;
+  applyIntent: (intent: LynxDeepLinkIntent) => LynxApplyDeepLinkResult;
+  setReady: (ready: boolean) => void;
+  setPairingHandler: (handler: ((pairing: LynxPairingConnectionPayload) => void) | null) => void;
+  setHandlers: (handlers: LynxDeepLinkHandlers) => void;
+  peekPending: () => LynxDeepLinkIntent | null;
+};
+
+export const createLynxDeepLinkInbox = (): LynxDeepLinkInbox => {
+  let ready = false;
+  let pending: LynxDeepLinkIntent | null = null;
+  let pairingHandler: ((pairing: LynxPairingConnectionPayload) => void) | null = null;
+  let handlers: LynxDeepLinkHandlers = {};
+
+  const execute = (intent: LynxDeepLinkIntent): boolean => {
+    switch (intent.type) {
+      case 'connect':
+        if (!pairingHandler) return false;
+        pairingHandler(intent.pairing);
+        return true;
+      case 'session':
+        if (!handlers.openSession) return false;
+        handlers.openSession(intent.sessionId, intent.directory);
+        return true;
+      case 'new-session':
+        if (!handlers.openDraft) return false;
+        handlers.openDraft(intent);
+        return true;
+      case 'open-project':
+        if (!handlers.openProject) return false;
+        handlers.openProject(intent.directory);
+        return true;
+      case 'sessions':
+        if (!handlers.openSessions) return false;
+        handlers.openSessions(intent.filter);
+        return true;
+      case 'status':
+        if (!handlers.openStatus) return false;
+        handlers.openStatus();
+        return true;
+      case 'settings':
+        if (!handlers.openSettings) return false;
+        handlers.openSettings(intent.section);
+        return true;
+      case 'changes':
+        if (!handlers.openChanges) return false;
+        handlers.openChanges({ path: intent.path, staged: intent.staged });
+        return true;
+      case 'view':
+        if (!handlers.openView) return false;
+        handlers.openView(intent.target);
+        return true;
+    }
+  };
+
+  const flush = (): LynxApplyDeepLinkResult | null => {
+    if (!pending || (!ready && pending.type !== 'connect')) return null;
+    const intent = pending;
+    pending = null;
+    if (!execute(intent)) {
+      pending = intent;
+      return { kind: 'stashed', intent };
+    }
+    if (intent.type === 'connect') return { kind: 'pairing-started', pairing: intent.pairing };
+    return { kind: 'navigation', intent };
+  };
+
+  const applyIntent = (intent: LynxDeepLinkIntent): LynxApplyDeepLinkResult => {
+    pending = intent;
+    return flush() ?? (intent.type === 'connect'
+      ? { kind: 'pairing-queued', pairing: intent.pairing }
+      : { kind: 'stashed', intent });
+  };
+
+  return {
+    applyUrl: (raw) => {
+      const intent = parseDeepLink(raw);
+      if (!intent) return { kind: 'ignored' };
+      return applyIntent(intent);
+    },
+    applyIntent,
+    setReady: (value) => {
+      ready = value;
+      flush();
+    },
+    setPairingHandler: (handler) => {
+      pairingHandler = handler;
+      flush();
+    },
+    setHandlers: (next) => {
+      handlers = next;
+      flush();
+    },
+    peekPending: () => pending,
+  };
+};

--- a/packages/lynx/src/connect/candidates.test.ts
+++ b/packages/lynx/src/connect/candidates.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+
+import { createMemoryHost, jsonResponse } from '../host/memory.ts';
+import { refreshConnectionCandidates } from './candidates.ts';
+import { createLynxConnectionStore } from './store.ts';
+
+const relay = {
+  relayUrl: 'wss://relay.example/ws',
+  serverId: 'srv_1',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' } as JsonWebKey,
+};
+
+describe('refreshConnectionCandidates', () => {
+  test('replaces stale LAN URLs from the official candidates route and keeps relayUrl', async () => {
+    const host = createMemoryHost({
+      runtimeFetch: async (path) => {
+        expect(path).toBe('/api/client-auth/connection/candidates');
+        return jsonResponse(200, {
+          serverId: 'srv_1',
+          candidates: [{ type: 'lan', url: 'http://192.168.1.77:2606' }],
+        });
+      },
+    });
+    const store = createLynxConnectionStore(host.metadataStore);
+    store.upsert({
+      id: 'home',
+      label: 'Home',
+      candidates: [
+        { kind: 'direct', url: 'http://192.168.1.9:2606' },
+        { kind: 'relay', relay },
+      ],
+      hasToken: true,
+    });
+    const active = store.load()[0]!;
+    const result = await refreshConnectionCandidates(active, host);
+    expect(result.result).toBe('updated');
+    expect(result.next?.candidates).toEqual([
+      { kind: 'direct', url: 'http://192.168.1.77:2606' },
+      { kind: 'relay', relay },
+    ]);
+  });
+
+  test('ignores a refresh that does not echo the paired serverId', async () => {
+    const host = createMemoryHost({
+      runtimeFetch: async () => jsonResponse(200, {
+        serverId: 'other',
+        candidates: [{ type: 'lan', url: 'http://10.0.0.2:2606' }],
+      }),
+    });
+    const active = {
+      id: 'home',
+      label: 'Home',
+      lastUsedAt: 1,
+      hasToken: true,
+      candidates: [{ kind: 'relay' as const, relay }],
+    };
+    const result = await refreshConnectionCandidates(active, host);
+    expect(result.result).toBe('skipped');
+  });
+});

--- a/packages/lynx/src/connect/candidates.ts
+++ b/packages/lynx/src/connect/candidates.ts
@@ -1,0 +1,69 @@
+import type { LynxHostAdapters } from '../host/adapters.ts';
+import { createLynxConnectionStore } from './store.ts';
+import { LYNX_RELAY_CONNECT_TIMEOUT_MS, type LynxCandidateRefreshResult, type LynxSavedConnection, type LynxTransportCandidate } from './types.ts';
+import { directCandidates, normalizeConnectionUrl, relayCandidateOf, serializeCandidate } from './urls.ts';
+import { safeLogInfo } from './sanitizeLog.ts';
+
+/**
+ * Learn current LAN addresses over the already-bound runtime.
+ * Official route: `GET /api/client-auth/connection/candidates`.
+ */
+export const refreshConnectionCandidates = async (
+  active: LynxSavedConnection,
+  host: LynxHostAdapters,
+): Promise<{ result: LynxCandidateRefreshResult; next?: LynxSavedConnection }> => {
+  const relay = relayCandidateOf(active);
+  if (!relay || !host.runtimeFetch) {
+    safeLogInfo(host.logger, 'candidates:refresh-skip', { reason: relay ? 'no-runtime-fetch' : 'no-relay-candidate' });
+    return { result: 'skipped' };
+  }
+  const response = await host.runtimeFetch('/api/client-auth/connection/candidates', {
+    method: 'GET',
+    timeoutMs: LYNX_RELAY_CONNECT_TIMEOUT_MS,
+  }).catch(() => null);
+  if (!response?.ok) {
+    safeLogInfo(host.logger, 'candidates:refresh-skip', { reason: 'fetch-failed', status: response?.status ?? null });
+    return { result: 'skipped' };
+  }
+  const payload = await response.json().catch(() => null) as { serverId?: unknown; candidates?: unknown } | null;
+  if (!payload || payload.serverId !== relay.serverId) {
+    safeLogInfo(host.logger, 'candidates:refresh-skip', { reason: 'server-id-mismatch' });
+    return { result: 'skipped' };
+  }
+  const reported = Array.isArray(payload.candidates) ? payload.candidates : [];
+  const lanUrls: string[] = [];
+  for (const entry of reported) {
+    if (!entry || typeof entry !== 'object') continue;
+    const record = entry as Record<string, unknown>;
+    if (record.type !== 'lan' || typeof record.url !== 'string') continue;
+    try {
+      const url = normalizeConnectionUrl(record.url);
+      if (url && !lanUrls.includes(url)) lanUrls.push(url);
+    } catch {
+      // drop invalid
+    }
+  }
+  if (lanUrls.length === 0) {
+    safeLogInfo(host.logger, 'candidates:refresh-skip', { reason: 'no-lan-reported' });
+    return { result: 'skipped' };
+  }
+  const preservedHttps = directCandidates(active).filter((candidate) => candidate.url.startsWith('https://'));
+  const nextCandidates: LynxTransportCandidate[] = [
+    ...lanUrls.map((url): LynxTransportCandidate => ({ kind: 'direct', url })),
+    ...preservedHttps,
+    { kind: 'relay', relay },
+  ];
+  const unchanged = JSON.stringify(active.candidates.map(serializeCandidate)) === JSON.stringify(nextCandidates.map(serializeCandidate));
+  if (unchanged) return { result: 'unchanged' };
+  const store = createLynxConnectionStore(host.metadataStore);
+  const list = store.upsert({
+    id: active.id,
+    label: active.label,
+    candidates: nextCandidates,
+    hasToken: active.hasToken,
+    now: host.clock?.now(),
+  });
+  const next = list.find((connection) => connection.id === active.id);
+  safeLogInfo(host.logger, 'candidates:refreshed', { lanCount: lanUrls.length });
+  return { result: 'updated', next };
+};

--- a/packages/lynx/src/connect/controller.test.ts
+++ b/packages/lynx/src/connect/controller.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  createMemoryHost,
+  createMemoryJsonStore,
+  createMemorySecureStore,
+  jsonResponse,
+} from '../host/memory.ts';
+import { createLynxConnectionController } from './controller.ts';
+import { encodePairingConnectionPayload, buildPairingConnectionPayload } from './pairing.ts';
+import { parseConnectionPayload } from './qr.ts';
+import { prefixedTokenKey } from './store.ts';
+import { LYNX_METADATA_STORAGE_KEY } from './types.ts';
+import { secureTokenKeyOf } from './urls.ts';
+
+const hostEncPubJwk = { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' } as const;
+const relay = {
+  relayUrl: 'wss://relay.example/ws',
+  serverId: 'srv_1',
+  hostEncPubJwk,
+};
+
+const pairing = buildPairingConnectionPayload({
+  pairingId: 'pair_abc',
+  secret: 'one-time',
+  label: 'Studio',
+  candidates: [
+    { type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 },
+    { type: 'relay', relayUrl: relay.relayUrl, serverId: relay.serverId, hostEncPubJwk, priority: 30 },
+  ],
+});
+
+describe('createLynxConnectionController', () => {
+  test('resolveLaunch holds splash then auto-connects via GET /health + /auth/session', async () => {
+    const metadata = createMemoryJsonStore();
+    const secure = createMemorySecureStore();
+    const storeHost = createMemoryHost({ metadataStore: metadata, secureStore: secure });
+    const bootstrap = createLynxConnectionController(storeHost);
+    await bootstrap.saveConnection({
+      label: 'Home',
+      candidates: [{ kind: 'direct', url: 'http://192.168.1.9:2606' }],
+      clientToken: 'saved-token',
+    });
+
+    const binds: Array<{ token: string | null; url?: string }> = [];
+    const logs: Array<{ step: string; detail?: Record<string, unknown> }> = [];
+    const controller = createLynxConnectionController({
+      ...createMemoryHost({ metadataStore: metadata, secureStore: secure }),
+      request: async (url) => {
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok' });
+        if (url.endsWith('/auth/session')) return jsonResponse(200, { authenticated: true, scope: 'client' });
+        return jsonResponse(404, null);
+      },
+      bindRuntime: (bind) => {
+        binds.push({ token: bind.clientToken, url: bind.transport.kind === 'direct' ? bind.transport.url : undefined });
+      },
+      logger: {
+        info: (step, detail) => logs.push({ step, detail }),
+        warn: (step, detail) => logs.push({ step, detail }),
+      },
+    });
+
+    expect(controller.snapshot().phase).toBe('resolving');
+    expect(controller.snapshot().autoConnectLabel).toBe('Home');
+    const connected = await controller.resolveLaunch();
+    expect(connected).toBe(true);
+    expect(controller.snapshot().phase).toBe('connected');
+    expect(binds[0]).toEqual({ token: 'saved-token', url: 'http://192.168.1.9:2606' });
+    expect(JSON.stringify(logs)).not.toContain('saved-token');
+  });
+
+  test('redeem v2 hits official pairing/redeem once and persists LAN+relay', async () => {
+    const redeemBodies: string[] = [];
+    const secure = createMemorySecureStore();
+    const metadata = createMemoryJsonStore();
+    const controller = createLynxConnectionController({
+      ...createMemoryHost({ metadataStore: metadata, secureStore: secure }),
+      request: async (url, init) => {
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok', serverId: 'srv_1' });
+        if (url.endsWith('/api/client-auth/pairing/redeem')) {
+          redeemBodies.push(init?.body ?? '');
+          return jsonResponse(200, {
+            ok: true,
+            clientToken: 'issued-token',
+            server: { label: 'Studio Mac' },
+          });
+        }
+        return jsonResponse(404, null);
+      },
+    });
+
+    await controller.redeemPairing(pairing);
+    expect(controller.snapshot().phase).toBe('connected');
+    expect(controller.snapshot().connections[0]?.candidates.map((candidate) => candidate.kind)).toEqual(['direct', 'relay']);
+    expect(controller.snapshot().connections[0]?.candidates[1]).toEqual({ kind: 'relay', relay });
+    const raw = JSON.parse(metadata.read(LYNX_METADATA_STORAGE_KEY) || '[]') as Array<Record<string, unknown>>;
+    expect(raw[0]?.clientToken).toBeUndefined();
+    const key = prefixedTokenKey(secureTokenKeyOf(controller.snapshot().connections[0]!));
+    expect(secure.snapshot()[key]).toBe('issued-token');
+    expect(redeemBodies).toHaveLength(1);
+    const body = JSON.parse(redeemBodies[0] || '{}') as { pairingId?: string; secret?: string; clientKind?: string };
+    expect(body).toMatchObject({ pairingId: 'pair_abc', secret: 'one-time', clientKind: 'mobile' });
+  });
+
+  test('does not invent a nearby redeem path', async () => {
+    const urls: string[] = [];
+    const controller = createLynxConnectionController({
+      ...createMemoryHost(),
+      request: async (url) => {
+        urls.push(url);
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok' });
+        if (url.endsWith('/api/client-auth/pairing/redeem')) {
+          return jsonResponse(200, { ok: true, clientToken: 't' });
+        }
+        return jsonResponse(404, null);
+      },
+    });
+    await controller.redeemPairing(buildPairingConnectionPayload({
+      pairingId: 'pair_1',
+      secret: 's',
+      candidates: [{ type: 'lan', url: 'http://10.0.0.8:2606' }],
+    }));
+    expect(urls.some((url) => url.includes('/nearby'))).toBe(false);
+    expect(urls.some((url) => url.endsWith('/api/client-auth/pairing/redeem'))).toBe(true);
+  });
+
+  test('password unlock posts issueClientToken and stores the bearer', async () => {
+    const secure = createMemorySecureStore();
+    const controller = createLynxConnectionController({
+      ...createMemoryHost({ secureStore: secure }),
+      request: async (url, init) => {
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok' });
+        if (url.endsWith('/auth/session') && (init?.method ?? 'GET') === 'GET') {
+          return jsonResponse(401, { authenticated: false });
+        }
+        if (url.endsWith('/auth/session') && init?.method === 'POST') {
+          const body = JSON.parse(init.body || '{}') as { issueClientToken?: boolean; password?: string };
+          expect(body.issueClientToken).toBe(true);
+          expect(body.password).toBe('hunter2');
+          return jsonResponse(200, { authenticated: true, clientToken: 'new-token' });
+        }
+        return jsonResponse(404, null);
+      },
+    });
+
+    await controller.connect({ url: 'http://192.168.1.9:2606', label: 'Home' });
+    expect(controller.snapshot().phase).toBe('password');
+    await controller.submitPassword('hunter2');
+    expect(controller.snapshot().phase).toBe('connected');
+    expect(Object.values(secure.snapshot())).toContain('new-token');
+  });
+
+  test('delete removes metadata and the secure token', async () => {
+    const secure = createMemorySecureStore();
+    const controller = createLynxConnectionController(createMemoryHost({ secureStore: secure }));
+    const saved = await controller.saveConnection({
+      label: 'Home',
+      url: 'http://192.168.1.9:2606',
+      clientToken: 'tok',
+    });
+    expect(saved).not.toBeNull();
+    expect(Object.keys(secure.snapshot())).toHaveLength(1);
+    await controller.removeConnection(saved!.id);
+    expect(controller.snapshot().connections).toEqual([]);
+    expect(secure.snapshot()).toEqual({});
+  });
+
+  test('scanAndConnect parses a pairing QR and a bare URL; host camera is optional', async () => {
+    const controller = createLynxConnectionController({
+      ...createMemoryHost(),
+      request: async (url) => {
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok' });
+        if (url.endsWith('/api/client-auth/pairing/redeem')) {
+          return jsonResponse(200, { ok: true, clientToken: 'from-qr' });
+        }
+        if (url.endsWith('/auth/session')) return jsonResponse(200, { authenticated: true, scope: 'client' });
+        return jsonResponse(404, null);
+      },
+      scanQr: async () => ({ status: 'ok', raw: encodePairingConnectionPayload(pairing) }),
+    });
+    await controller.scanAndConnect();
+    expect(controller.snapshot().phase).toBe('connected');
+
+    const noCamera = createLynxConnectionController(createMemoryHost());
+    await noCamera.scanAndConnect();
+    expect(noCamera.snapshot().error).toBe('scan-unsupported');
+  });
+
+  test('applyDeepLinkUrl redeem v2 and ignores v1', async () => {
+    const controller = createLynxConnectionController({
+      ...createMemoryHost(),
+      request: async (url) => {
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok' });
+        if (url.endsWith('/api/client-auth/pairing/redeem')) {
+          return jsonResponse(200, { ok: true, clientToken: 'deeplink' });
+        }
+        return jsonResponse(404, null);
+      },
+    });
+    const applied = controller.applyDeepLinkUrl(encodePairingConnectionPayload(pairing));
+    expect(applied.kind === 'pairing-started' || applied.kind === 'pairing-queued').toBe(true);
+    await vi.waitFor(() => {
+      expect(controller.snapshot().phase).toBe('connected');
+    });
+    expect(controller.applyDeepLinkUrl('openchamber://connect?v=1&token=nope').kind).toBe('ignored');
+  });
+});
+
+describe('QR / paste parse', () => {
+  test('accepts a v2 pairing link and a bare http URL; rejects v1', () => {
+    expect(parseConnectionPayload(encodePairingConnectionPayload(pairing))?.kind).toBe('pairing');
+    expect(parseConnectionPayload('https://oc.example')).toEqual({ kind: 'url', url: 'https://oc.example' });
+    expect(parseConnectionPayload('openchamber://connect?v=1&token=secret')).toBeNull();
+    expect(parseConnectionPayload('openchamber://session/abc')).toBeNull();
+  });
+});

--- a/packages/lynx/src/connect/controller.ts
+++ b/packages/lynx/src/connect/controller.ts
@@ -1,0 +1,493 @@
+import type { LynxHostAdapters } from '../host/adapters.ts';
+import { createLynxDeepLinkInbox, type LynxApplyDeepLinkResult, type LynxDeepLinkInbox } from './applyDeepLink.ts';
+import { refreshConnectionCandidates } from './candidates.ts';
+import { createLynxId, readOrCreateDeviceId } from './ids.ts';
+import { loginWithPasswordOnTransport } from './password.ts';
+import {
+  establishLiveTransport,
+  pairingCandidatesToMobile,
+  probeConnectionCandidates,
+  validateDirectSession,
+} from './probe.ts';
+import { qrScanStatusToError, resultFromQrRaw } from './qr.ts';
+import { redeemPairingOnTransport } from './redeem.ts';
+import { safeLogInfo, safeLogWarn } from './sanitizeLog.ts';
+import {
+  createLynxConnectionStore,
+  deleteSecureToken,
+  migrateLegacyInlineTokens,
+  readSecureToken,
+  writeSecureToken,
+  type LynxConnectionStore,
+} from './store.ts';
+import {
+  type LynxConnectError,
+  type LynxConnectInput,
+  type LynxConnectPhase,
+  type LynxPairingConnectionPayload,
+  type LynxPendingConnection,
+  type LynxReprobeOutcome,
+  type LynxSavedConnection,
+  type LynxTransportCandidate,
+} from './types.ts';
+import {
+  candidateSetsMatch,
+  connectionDisplayUrl,
+  directCandidates,
+  getConnectionLabel,
+  isSameConnectionUrl,
+  normalizeConnectionUrl,
+  relayCandidateOf,
+  secureTokenKeyOf,
+} from './urls.ts';
+
+export type LynxConnectionSnapshot = {
+  phase: LynxConnectPhase;
+  autoConnectLabel: string | null;
+  connections: LynxSavedConnection[];
+  pendingConnection: LynxPendingConnection | null;
+  error: LynxConnectError | null;
+  busy: boolean;
+  passwordBusy: boolean;
+};
+
+export type LynxConnectionController = {
+  snapshot: () => LynxConnectionSnapshot;
+  subscribe: (listener: () => void) => () => void;
+  resolveLaunch: () => Promise<boolean>;
+  autoConnectLastInstance: () => Promise<boolean>;
+  connect: (input: LynxConnectInput) => Promise<void>;
+  redeemPairing: (payload: LynxPairingConnectionPayload) => Promise<void>;
+  submitPassword: (password: string) => Promise<void>;
+  cancelPassword: () => void;
+  saveConnection: (input: LynxConnectInput) => Promise<LynxSavedConnection | null>;
+  removeConnection: (id: string) => Promise<LynxSavedConnection | null>;
+  scanAndConnect: () => Promise<void>;
+  applyDeepLinkUrl: (raw: string | null | undefined) => LynxApplyDeepLinkResult;
+  deepLinks: LynxDeepLinkInbox;
+  setReady: (ready: boolean) => void;
+  setError: (error: LynxConnectError | null) => void;
+  reprobeActive: () => Promise<LynxReprobeOutcome>;
+  refreshCandidates: () => Promise<void>;
+};
+
+const buildCandidatesFromInput = (input: LynxConnectInput): LynxTransportCandidate[] => {
+  if (input.candidates && input.candidates.length > 0) return input.candidates;
+  const list: LynxTransportCandidate[] = [];
+  if (typeof input.url === 'string' && input.url.trim() && !/^relay:\/\//i.test(input.url.trim())) {
+    try {
+      const url = normalizeConnectionUrl(input.url);
+      if (url) list.push({ kind: 'direct', url });
+    } catch {
+      // invalid
+    }
+  }
+  if (input.relay) list.push({ kind: 'relay', relay: input.relay });
+  return list;
+};
+
+export const createLynxConnectionController = (host: LynxHostAdapters): LynxConnectionController => {
+  const store: LynxConnectionStore = createLynxConnectionStore(host.metadataStore);
+  const createId = host.createId ?? createLynxId;
+  const deepLinks = createLynxDeepLinkInbox();
+  const listeners = new Set<() => void>();
+
+  let connections = store.load();
+  let phase: LynxConnectPhase = 'resolving';
+  let pendingConnection: LynxPendingConnection | null = null;
+  let error: LynxConnectError | null = null;
+  let busyOperation: 'connect' | 'password' | 'pairing' | null = null;
+  let boundKey: string | null = host.getRuntimeKey?.() ?? null;
+
+  const deviceId = () => readOrCreateDeviceId(host.metadataStore, createId);
+
+  const emit = () => {
+    listeners.forEach((listener) => listener());
+  };
+
+  const snapshot = (): LynxConnectionSnapshot => ({
+    phase,
+    autoConnectLabel: connections[0]?.label?.trim() ? connections[0].label : null,
+    connections,
+    pendingConnection,
+    error,
+    busy: busyOperation !== null,
+    passwordBusy: busyOperation === 'password',
+  });
+
+  const applyConnections = (next: LynxSavedConnection[]) => {
+    connections = next;
+    emit();
+  };
+
+  const persistMetadata = (draft: {
+    id?: string;
+    label: string;
+    candidates: LynxTransportCandidate[];
+    hasToken?: boolean;
+  }) => {
+    const next = store.upsert({
+      ...draft,
+      now: host.clock?.now(),
+      createId,
+    });
+    applyConnections(next);
+    return next;
+  };
+
+  const bind = (candidates: LynxTransportCandidate[], token: string | null, transport: { kind: 'direct'; url: string } | { kind: 'relay'; relay: NonNullable<ReturnType<typeof relayCandidateOf>> }) => {
+    const runtimeKey = secureTokenKeyOf({ candidates });
+    boundKey = runtimeKey;
+    host.bindRuntime?.({ runtimeKey, transport, clientToken: token });
+    phase = 'connected';
+    pendingConnection = null;
+    emit();
+  };
+
+  const autoConnectLastInstance = async (): Promise<boolean> => {
+    await migrateLegacyInlineTokens(host.metadataStore, host.secureStore);
+    connections = store.load();
+    const candidate = connections[0];
+    if (!candidate?.hasToken) return false;
+    const token = await readSecureToken(host.secureStore, candidate);
+    if (!token) return false;
+    const result = await probeConnectionCandidates(candidate.candidates, token, host);
+    if (result.status !== 'ok') return false;
+    persistMetadata({ id: candidate.id, label: candidate.label, candidates: candidate.candidates, hasToken: true });
+    bind(candidate.candidates, token, result.transport);
+    return true;
+  };
+
+  const resolveLaunch = async (): Promise<boolean> => {
+    phase = 'resolving';
+    error = null;
+    emit();
+    const connected = await autoConnectLastInstance();
+    if (!connected) {
+      phase = pendingConnection ? 'password' : 'welcome';
+      emit();
+    }
+    return connected;
+  };
+
+  const connect = async (input: LynxConnectInput): Promise<void> => {
+    error = null;
+    busyOperation = 'connect';
+    emit();
+    try {
+      const candidates = buildCandidatesFromInput(input);
+      if (candidates.length === 0) {
+        error = 'url-required';
+        return;
+      }
+      const saved = input.id
+        ? connections.find((connection) => connection.id === input.id)
+        : connections.find((connection) => candidateSetsMatch(connection.candidates, candidates));
+      const label = input.label?.trim() || saved?.label || getConnectionLabel(connectionDisplayUrl({ candidates }));
+      let token = input.clientToken?.trim() || undefined;
+      const tokenIsNew = Boolean(token);
+      if (!token && saved?.hasToken) token = await readSecureToken(host.secureStore, saved);
+
+      safeLogInfo(host.logger, 'connect:start', {
+        candidates: candidates.map((candidate) => candidate.kind),
+        hasToken: Boolean(token),
+      });
+
+      const result = await probeConnectionCandidates(candidates, token, host, { grant: input.relayGrant });
+      safeLogInfo(host.logger, 'connect:probe', { status: result.status });
+
+      if (result.status === 'unreachable') {
+        error = 'unreachable';
+        return;
+      }
+      if (result.status === 'needs-login') {
+        persistMetadata({ id: saved?.id, label, candidates, hasToken: Boolean(token) });
+        pendingConnection = {
+          id: saved?.id ?? createId(),
+          label,
+          candidates,
+          relay: relayCandidateOf({ candidates }) ?? undefined,
+          relayGrant: input.relayGrant,
+        };
+        phase = 'password';
+        return;
+      }
+
+      if (token && tokenIsNew) {
+        const stored = await writeSecureToken(host.secureStore, { candidates }, token);
+        if (!stored) {
+          error = 'secure-store-failed';
+          return;
+        }
+      }
+      persistMetadata({ id: saved?.id, label, candidates, hasToken: Boolean(token) });
+      bind(candidates, token ?? null, result.transport);
+    } catch (caught) {
+      safeLogWarn(host.logger, 'connect:threw', { error: caught instanceof Error ? caught.message : 'error' });
+      error = 'invalid-url';
+    } finally {
+      if (busyOperation === 'connect') busyOperation = null;
+      emit();
+    }
+  };
+
+  const redeemPairing = async (payload: LynxPairingConnectionPayload): Promise<void> => {
+    if (busyOperation === 'pairing') return;
+    error = null;
+    busyOperation = 'pairing';
+    emit();
+    const deviceCandidates = pairingCandidatesToMobile(payload.candidates);
+    let chosen: Awaited<ReturnType<typeof establishLiveTransport>> = null;
+    try {
+      chosen = await establishLiveTransport(deviceCandidates, host);
+      if (!chosen) {
+        error = 'unreachable';
+        return;
+      }
+      const redeemed = await redeemPairingOnTransport(chosen, payload, host, { deviceId: deviceId() });
+      if (!redeemed) {
+        error = 'auth-required';
+        return;
+      }
+      const label = payload.label || redeemed.serverLabel || getConnectionLabel(connectionDisplayUrl({ candidates: deviceCandidates }));
+      const stored = await writeSecureToken(host.secureStore, { candidates: deviceCandidates }, redeemed.token);
+      if (!stored) {
+        error = 'secure-store-failed';
+        return;
+      }
+      persistMetadata({ label, candidates: deviceCandidates, hasToken: true });
+      bind(
+        deviceCandidates,
+        redeemed.token,
+        chosen.kind === 'relay' ? { kind: 'relay', relay: chosen.relay } : { kind: 'direct', url: chosen.url },
+      );
+    } catch (caught) {
+      safeLogWarn(host.logger, 'pairing:threw', { error: caught instanceof Error ? caught.message : 'error' });
+      error = 'auth-required';
+    } finally {
+      if (chosen?.kind === 'relay') chosen.tunnel.close?.();
+      if (busyOperation === 'pairing') busyOperation = null;
+      emit();
+    }
+  };
+
+  const submitPassword = async (password: string): Promise<void> => {
+    if (!pendingConnection || !password.trim() || busyOperation === 'password') return;
+    error = null;
+    busyOperation = 'password';
+    emit();
+    const { id, label, candidates } = pendingConnection;
+    let chosen: Awaited<ReturnType<typeof establishLiveTransport>> = null;
+    try {
+      chosen = await establishLiveTransport(candidates, host);
+      if (!chosen) {
+        error = 'unreachable';
+        return;
+      }
+      safeLogInfo(host.logger, 'password:start', { transport: chosen.kind });
+      const issued = await loginWithPasswordOnTransport(chosen, password, host, { deviceId: deviceId() });
+      safeLogInfo(host.logger, 'password:done', { issued: Boolean(issued) });
+      if (!issued) {
+        error = 'password-failed';
+        return;
+      }
+      const stored = await writeSecureToken(host.secureStore, { candidates }, issued.token);
+      if (!stored) {
+        error = 'secure-store-failed';
+        return;
+      }
+      persistMetadata({ id, label, candidates, hasToken: true });
+      bind(
+        candidates,
+        issued.token,
+        chosen.kind === 'relay' ? { kind: 'relay', relay: chosen.relay } : { kind: 'direct', url: chosen.url },
+      );
+    } catch (caught) {
+      safeLogWarn(host.logger, 'password:threw', { error: caught instanceof Error ? caught.message : 'error' });
+      error = 'password-failed';
+    } finally {
+      if (chosen?.kind === 'relay') chosen.tunnel.close?.();
+      if (busyOperation === 'password') busyOperation = null;
+      emit();
+    }
+  };
+
+  const saveConnection = async (input: LynxConnectInput): Promise<LynxSavedConnection | null> => {
+    error = null;
+    let candidates = buildCandidatesFromInput(input);
+    const existing = input.id ? connections.find((connection) => connection.id === input.id) ?? null : null;
+    if (existing) {
+      const inputDirects = candidates.filter((candidate): candidate is Extract<LynxTransportCandidate, { kind: 'direct' }> => candidate.kind === 'direct');
+      const preservedHttps = directCandidates(existing).filter(
+        (candidate) => candidate.url.startsWith('https://') && !inputDirects.some((next) => isSameConnectionUrl(next.url, candidate.url)),
+      );
+      const relay = relayCandidateOf(existing);
+      candidates = [...inputDirects, ...preservedHttps, ...(relay ? [{ kind: 'relay' as const, relay }] : [])];
+    }
+    if (candidates.length === 0) {
+      error = 'url-required';
+      emit();
+      return null;
+    }
+    const clientToken = input.clientToken?.trim() || undefined;
+    const label = input.label?.trim() || getConnectionLabel(connectionDisplayUrl({ candidates }));
+    const nextKey = secureTokenKeyOf({ candidates });
+    if (clientToken) {
+      const stored = await writeSecureToken(host.secureStore, { candidates }, clientToken);
+      if (!stored) {
+        error = 'secure-store-failed';
+        emit();
+        return null;
+      }
+    } else if (existing?.hasToken) {
+      const previousKey = secureTokenKeyOf(existing);
+      if (previousKey && nextKey && previousKey !== nextKey) {
+        const storedToken = await readSecureToken(host.secureStore, existing);
+        if (storedToken) await writeSecureToken(host.secureStore, { candidates }, storedToken);
+      }
+    }
+    const next = persistMetadata({
+      id: input.id,
+      label,
+      candidates,
+      hasToken: Boolean(clientToken) || existing?.hasToken,
+    });
+    return next.find((connection) => candidateSetsMatch(connection.candidates, candidates)) ?? null;
+  };
+
+  const removeConnection = async (id: string): Promise<LynxSavedConnection | null> => {
+    const { next, removed } = store.remove(id);
+    if (removed) await deleteSecureToken(host.secureStore, removed);
+    applyConnections(next);
+    if (removed && secureTokenKeyOf(removed) === boundKey) {
+      boundKey = null;
+      phase = 'welcome';
+      host.bindRuntime?.({
+        runtimeKey: 'mobile-disconnected',
+        transport: { kind: 'direct', url: '' },
+        clientToken: null,
+      });
+    }
+    return removed;
+  };
+
+  const scanAndConnect = async (): Promise<void> => {
+    if (!host.scanQr) {
+      error = 'scan-unsupported';
+      emit();
+      return;
+    }
+    error = null;
+    emit();
+    const scanned = await host.scanQr();
+    if (scanned.status === 'cancelled') return;
+    if (scanned.status !== 'ok') {
+      error = qrScanStatusToError(scanned.status);
+      emit();
+      return;
+    }
+    const parsed = resultFromQrRaw(scanned.raw);
+    if (parsed.status === 'invalid') {
+      error = 'scan-invalid';
+      emit();
+      return;
+    }
+    if (parsed.status === 'pairing') {
+      await redeemPairing(parsed.pairing);
+      return;
+    }
+    await connect({ url: parsed.url, clientToken: parsed.clientToken, label: parsed.label });
+  };
+
+  deepLinks.setPairingHandler((pairing) => {
+    void redeemPairing(pairing);
+  });
+
+  const applyDeepLinkUrl = (raw: string | null | undefined): LynxApplyDeepLinkResult =>
+    deepLinks.applyUrl(raw);
+
+  const transportMatchesCurrent = (connection: LynxSavedConnection): number => {
+    const relayActive = host.isRelayModeActive?.() === true;
+    const directUrl = host.getRuntimeDirectUrl?.() ?? '';
+    return connection.candidates.findIndex((candidate) => (
+      candidate.kind === 'relay'
+        ? relayActive
+        : !relayActive && Boolean(directUrl) && isSameConnectionUrl(candidate.url, directUrl)
+    ));
+  };
+
+  const reprobeActive = async (): Promise<LynxReprobeOutcome> => {
+    const runtimeKey = host.getRuntimeKey?.() ?? boundKey;
+    if (!runtimeKey) return 'no-connection';
+    const active = connections.find((connection) => secureTokenKeyOf(connection) === runtimeKey) ?? null;
+    if (!active) return 'no-connection';
+    const token = active.hasToken ? await readSecureToken(host.secureStore, active) : undefined;
+    if (!token) return 'unreachable';
+    const currentIndex = transportMatchesCurrent(active);
+    const higher = currentIndex >= 0 ? active.candidates.slice(0, currentIndex) : active.candidates;
+    const better = await probeConnectionCandidates(higher, token, host, { fast: true });
+    if (better.status === 'ok') {
+      persistMetadata({ id: active.id, label: active.label, candidates: active.candidates, hasToken: true });
+      bind(active.candidates, token, better.transport);
+      return 'switched';
+    }
+    if (better.status === 'needs-login') return 'unreachable';
+    if (currentIndex >= 0) {
+      const current = active.candidates[currentIndex];
+      if (current?.kind === 'direct') {
+        const stillValid = await validateDirectSession(current.url, token, host, { fast: true });
+        if (stillValid) return 'unchanged';
+      } else if (host.runtimeFetch) {
+        const session = await host.runtimeFetch('/auth/session', { method: 'GET' }).catch(() => null);
+        if (session && session.status !== 401) return 'unchanged';
+      }
+    }
+    const lower = currentIndex >= 0 ? active.candidates.slice(currentIndex + 1) : [];
+    const fallback = await probeConnectionCandidates(lower, token, host, { fast: true });
+    if (fallback.status === 'ok') {
+      persistMetadata({ id: active.id, label: active.label, candidates: active.candidates, hasToken: true });
+      bind(active.candidates, token, fallback.transport);
+      return 'switched';
+    }
+    return 'unreachable';
+  };
+
+  const refreshCandidates = async (): Promise<void> => {
+    const runtimeKey = host.getRuntimeKey?.() ?? boundKey;
+    const active = connections.find((connection) => secureTokenKeyOf(connection) === runtimeKey) ?? null;
+    if (!active) return;
+    const result = await refreshConnectionCandidates(active, host);
+    if (result.next) applyConnections(store.load());
+  };
+
+  return {
+    snapshot,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    resolveLaunch,
+    autoConnectLastInstance,
+    connect,
+    redeemPairing,
+    submitPassword,
+    cancelPassword: () => {
+      pendingConnection = null;
+      error = null;
+      if (phase === 'password') phase = 'welcome';
+      emit();
+    },
+    saveConnection,
+    removeConnection,
+    scanAndConnect,
+    applyDeepLinkUrl,
+    deepLinks,
+    setReady: (ready) => deepLinks.setReady(ready),
+    setError: (next) => {
+      error = next;
+      emit();
+    },
+    reprobeActive,
+    refreshCandidates,
+  };
+};

--- a/packages/lynx/src/connect/deepLinks.test.ts
+++ b/packages/lynx/src/connect/deepLinks.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildPairingConnectionPayload, encodePairingConnectionPayload } from './pairing.ts';
+import { buildDeepLink, parseDeepLink } from './deepLinks.ts';
+import { createLynxDeepLinkInbox } from './applyDeepLink.ts';
+
+const pairing = buildPairingConnectionPayload({
+  pairingId: 'pair_deep_link',
+  secret: 'one-time-secret',
+  candidates: [{ type: 'lan', url: 'http://192.168.1.20:4096' }],
+});
+
+describe('parseDeepLink', () => {
+  test('parses the same intent union as Cap', () => {
+    expect(parseDeepLink(encodePairingConnectionPayload(pairing))).toEqual({ type: 'connect', pairing });
+    expect(parseDeepLink('openchamber://session/ses_1?directory=/tmp/demo')).toEqual({
+      type: 'session',
+      sessionId: 'ses_1',
+      directory: '/tmp/demo',
+    });
+    expect(parseDeepLink('openchamber://new-session?directory=/tmp/demo&prompt=hello%20world')).toEqual({
+      type: 'new-session',
+      directory: '/tmp/demo',
+      projectId: undefined,
+      agent: undefined,
+      model: undefined,
+      prompt: 'hello world',
+    });
+    expect(parseDeepLink('openchamber://new?dir=/legacy')?.type).toBe('new-session');
+    expect(parseDeepLink('openchamber://open-project?directory=/tmp/demo')).toEqual({
+      type: 'open-project',
+      directory: '/tmp/demo',
+    });
+    expect(parseDeepLink('openchamber://project/%2Ftmp%2Fdemo')).toEqual({
+      type: 'open-project',
+      directory: '/tmp/demo',
+    });
+    expect(parseDeepLink('openchamber://sessions?filter=attention')).toEqual({
+      type: 'sessions',
+      filter: 'attention',
+    });
+    expect(parseDeepLink('openchamber://status')).toEqual({ type: 'status' });
+    expect(parseDeepLink('openchamber://settings/appearance')).toEqual({
+      type: 'settings',
+      section: 'appearance',
+    });
+    expect(parseDeepLink('openchamber://changes/src/app.ts?staged=true')).toEqual({
+      type: 'changes',
+      path: 'src/app.ts',
+      staged: true,
+    });
+    expect(parseDeepLink('openchamber://view/instances')).toEqual({ type: 'view', target: 'instances' });
+    expect(parseDeepLink('openchamber://view/files')).toEqual({ type: 'view', target: 'files' });
+    expect(parseDeepLink('openchamber://view/mcp')).toEqual({ type: 'view', target: 'mcp' });
+    expect(parseDeepLink('openchamber://view/update')).toEqual({ type: 'view', target: 'update' });
+  });
+
+  test('rejects malformed and legacy connect links', () => {
+    expect(parseDeepLink('openchamber://connect?v=2&p=not-json')).toBeNull();
+    expect(parseDeepLink('openchamber://connect?v=1&server=https%3A%2F%2Fexample.com&token=secret')).toBeNull();
+    expect(parseDeepLink('openchamber://open-project')).toBeNull();
+    expect(parseDeepLink('https://example.com')).toBeNull();
+  });
+
+  test('rebuilds canonical URLs', () => {
+    expect(buildDeepLink({ type: 'connect', pairing })).toBe(encodePairingConnectionPayload(pairing));
+    expect(buildDeepLink({ type: 'new-session', directory: '/tmp/demo', prompt: 'ship it' })).toBe(
+      'openchamber://new-session?directory=%2Ftmp%2Fdemo&prompt=ship+it',
+    );
+    expect(buildDeepLink({ type: 'view', target: 'mcp' })).toBe('openchamber://view/mcp');
+  });
+});
+
+describe('deep link inbox', () => {
+  test('redeems pairing before the shell is ready and stashes navigation', () => {
+    const inbox = createLynxDeepLinkInbox();
+    const redeemed: string[] = [];
+    inbox.setPairingHandler((next) => {
+      redeemed.push(next.pairingId);
+    });
+
+    const pairingResult = inbox.applyUrl(encodePairingConnectionPayload(pairing));
+    expect(pairingResult.kind).toBe('pairing-started');
+    expect(redeemed).toEqual(['pair_deep_link']);
+
+    const nav = inbox.applyUrl('openchamber://session/ses_wait');
+    expect(nav.kind).toBe('stashed');
+    expect(inbox.peekPending()?.type).toBe('session');
+
+    let opened = '';
+    inbox.setHandlers({
+      openSession: (sessionId) => {
+        opened = sessionId;
+      },
+    });
+    inbox.setReady(true);
+    expect(opened).toBe('ses_wait');
+  });
+});

--- a/packages/lynx/src/connect/deepLinks.ts
+++ b/packages/lynx/src/connect/deepLinks.ts
@@ -1,0 +1,150 @@
+/**
+ * `openchamber://` intent union — same as Capacitor `packages/ui/src/apps/deepLinks.ts`.
+ * Connect is pairing v2 only. Legacy v1 token URLs stay rejected.
+ */
+
+import { encodePairingConnectionPayload, parsePairingConnectionPayload } from './pairing.ts';
+import type { LynxDeepLinkIntent, LynxSessionsFilter, LynxViewTarget } from './types.ts';
+
+export const DEEP_LINK_SCHEME = 'openchamber';
+
+const trimSlashes = (value: string): string => value.replace(/^\/+|\/+$/g, '');
+
+const readDirectoryParam = (query: URLSearchParams): string | undefined => {
+  const value = query.get('directory') || query.get('dir') || query.get('path');
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const segmentsOf = (url: URL): string[] => {
+  const pathSegments = trimSlashes(url.pathname).split('/').filter(Boolean);
+  if (url.host) return [url.host, ...pathSegments];
+  return pathSegments;
+};
+
+export function parseDeepLink(raw: string | null | undefined): LynxDeepLinkIntent | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== `${DEEP_LINK_SCHEME}:`) return null;
+
+  const segments = segmentsOf(url);
+  const route = (segments[0] ?? '').toLowerCase();
+  const rest = segments.slice(1);
+  const query = url.searchParams;
+
+  switch (route) {
+    case 'connect': {
+      const pairing = parsePairingConnectionPayload(raw);
+      return pairing ? { type: 'connect', pairing } : null;
+    }
+    case 'session': {
+      const sessionId = rest[0] || query.get('id') || '';
+      if (!sessionId) return null;
+      return { type: 'session', sessionId, directory: readDirectoryParam(query) };
+    }
+    case 'new':
+    case 'new-session': {
+      const prompt = query.get('prompt')?.trim();
+      return {
+        type: 'new-session',
+        directory: readDirectoryParam(query),
+        projectId: query.get('project') ?? undefined,
+        agent: query.get('agent') ?? undefined,
+        model: query.get('model') ?? undefined,
+        prompt: prompt || undefined,
+      };
+    }
+    case 'project':
+    case 'open-project': {
+      let fromPath: string | undefined;
+      if (rest.length > 0) {
+        try {
+          fromPath = decodeURIComponent(rest.join('/'));
+        } catch {
+          fromPath = rest.join('/');
+        }
+      }
+      const directory = readDirectoryParam(query) || fromPath;
+      if (!directory) return null;
+      return { type: 'open-project', directory };
+    }
+    case 'sessions': {
+      const filter = query.get('filter');
+      return {
+        type: 'sessions',
+        filter: filter === 'attention' || filter === 'recent' || filter === 'all' ? filter : undefined,
+      };
+    }
+    case 'status':
+      return { type: 'status' };
+    case 'settings':
+      return { type: 'settings', section: rest[0] || query.get('section') || undefined };
+    case 'changes':
+      return {
+        type: 'changes',
+        path: rest.join('/') || query.get('path') || undefined,
+        staged: query.get('staged') === 'true',
+      };
+    case 'view': {
+      const target = (rest[0] || '').toLowerCase();
+      if (target === 'changes') return { type: 'changes' };
+      if (target === 'files' || target === 'mcp' || target === 'instances' || target === 'update') {
+        return { type: 'view', target: target as LynxViewTarget };
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function buildDeepLink(intent: LynxDeepLinkIntent): string {
+  const base = `${DEEP_LINK_SCHEME}://`;
+  const withQuery = (path: string, params: Record<string, string | undefined>): string => {
+    const search = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (typeof value === 'string' && value.length > 0) search.set(key, value);
+    }
+    const query = search.toString();
+    return query ? `${base}${path}?${query}` : `${base}${path}`;
+  };
+
+  switch (intent.type) {
+    case 'connect':
+      return encodePairingConnectionPayload(intent.pairing);
+    case 'session':
+      return withQuery(`session/${encodeURIComponent(intent.sessionId)}`, { directory: intent.directory });
+    case 'new-session':
+      return withQuery('new-session', {
+        directory: intent.directory,
+        project: intent.projectId,
+        agent: intent.agent,
+        model: intent.model,
+        prompt: intent.prompt,
+      });
+    case 'open-project':
+      return withQuery('open-project', { directory: intent.directory });
+    case 'sessions':
+      return withQuery('sessions', { filter: intent.filter });
+    case 'status':
+      return `${base}status`;
+    case 'settings':
+      return intent.section ? `${base}settings/${encodeURIComponent(intent.section)}` : `${base}settings`;
+    case 'changes':
+      return withQuery(intent.path ? `changes/${intent.path}` : 'changes', {
+        staged: intent.staged ? 'true' : undefined,
+      });
+    case 'view':
+      return `${base}view/${intent.target}`;
+  }
+}
+
+export type { LynxDeepLinkIntent, LynxSessionsFilter, LynxViewTarget };

--- a/packages/lynx/src/connect/http.ts
+++ b/packages/lynx/src/connect/http.ts
@@ -1,0 +1,52 @@
+import type { LynxHttpInit, LynxSessionStatus } from './types.ts';
+
+export const readSessionStatus = async (
+  response: { json: () => Promise<unknown> } | null,
+): Promise<LynxSessionStatus | null> => {
+  if (!response) return null;
+  const payload = await response.json().catch(() => null);
+  if (!payload || typeof payload !== 'object') return null;
+  const record = payload as Record<string, unknown>;
+  return {
+    authenticated: typeof record.authenticated === 'boolean' ? record.authenticated : undefined,
+    disabled: typeof record.disabled === 'boolean' ? record.disabled : undefined,
+    scope: typeof record.scope === 'string' ? record.scope : undefined,
+    serverId: typeof record.serverId === 'string' ? record.serverId : undefined,
+  };
+};
+
+export const readHealthServerId = async (
+  response: { json: () => Promise<unknown> } | null,
+): Promise<string | null> => {
+  if (!response) return null;
+  const payload = await response.json().catch(() => null);
+  if (!payload || typeof payload !== 'object') return null;
+  const reported = (payload as Record<string, unknown>).serverId;
+  return typeof reported === 'string' && reported ? reported : null;
+};
+
+export const bearerHeaders = (token?: string): Record<string, string> | undefined =>
+  token ? { Authorization: `Bearer ${token}` } : undefined;
+
+export const jsonInit = (body: unknown, extra?: LynxHttpInit): LynxHttpInit => ({
+  method: extra?.method ?? 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...extra?.headers,
+  },
+  body: typeof extra?.body === 'string' ? extra.body : JSON.stringify(body),
+  timeoutMs: extra?.timeoutMs,
+});
+
+export const isAuthRejection = (status: LynxSessionStatus | null, httpStatus?: number): boolean => {
+  if (httpStatus === 401) return true;
+  return Boolean(status && status.disabled !== true && status.authenticated === false);
+};
+
+export const joinUrl = (base: string, path: string): string => {
+  const trimmedBase = base.replace(/\/+$/, '');
+  const trimmedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${trimmedBase}${trimmedPath}`;
+};
+

--- a/packages/lynx/src/connect/ids.ts
+++ b/packages/lynx/src/connect/ids.ts
@@ -1,0 +1,20 @@
+import { LYNX_DEVICE_ID_STORAGE_KEY } from './types.ts';
+import type { LynxJsonStore } from '../host/adapters.ts';
+
+export const createLynxId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `lynx_${Math.random().toString(16).slice(2)}${Date.now().toString(16)}`;
+};
+
+export const readOrCreateDeviceId = (store: LynxJsonStore, createId: () => string): string => {
+  const existing = store.read(LYNX_DEVICE_ID_STORAGE_KEY);
+  if (existing && existing.trim()) return existing.trim();
+  const generated = createId();
+  store.write(LYNX_DEVICE_ID_STORAGE_KEY, generated);
+  return generated;
+};
+
+export const mobileClientDedupeKey = (deviceId: string): string => `mobile:${deviceId}`;
+

--- a/packages/lynx/src/connect/index.ts
+++ b/packages/lynx/src/connect/index.ts
@@ -1,0 +1,65 @@
+export {
+  LYNX_CANDIDATE_REFRESH_DELAY_MS,
+  LYNX_CLIENT_KIND,
+  LYNX_CLIENT_LABEL,
+  LYNX_CONNECTIONS_LIMIT,
+  LYNX_CONNECT_TIMEOUT_MS,
+  LYNX_DEVICE_ID_STORAGE_KEY,
+  LYNX_FAST_PROBE_TIMEOUT_MS,
+  LYNX_METADATA_STORAGE_KEY,
+  LYNX_RELAY_CONNECT_TIMEOUT_MS,
+  LYNX_RELAY_RACE_HEADSTART_MS,
+  LYNX_SECURE_TIMEOUT_MS,
+  LYNX_SECURE_TOKEN_PREFIX,
+} from './types.ts';
+export type {
+  LynxCandidateRefreshResult,
+  LynxChosenTransport,
+  LynxConnectError,
+  LynxConnectInput,
+  LynxConnectPhase,
+  LynxConnectionMode,
+  LynxDeepLinkIntent,
+  LynxHttpInit,
+  LynxHttpResponse,
+  LynxHttpTransport,
+  LynxPairingConnectionPayload,
+  LynxPairingEndpointCandidate,
+  LynxPendingConnection,
+  LynxProbeResult,
+  LynxQrScanRaw,
+  LynxRelayConfig,
+  LynxReprobeOutcome,
+  LynxRuntimeBind,
+  LynxSavedConnection,
+  LynxSessionsFilter,
+  LynxTransportCandidate,
+  LynxViewTarget,
+} from './types.ts';
+
+export {
+  buildPairingConnectionPayload,
+  encodePairingConnectionPayload,
+  parsePairingConnectionPayload,
+  parsePairingConnectionPayloadString,
+} from './pairing.ts';
+export { buildDeepLink, DEEP_LINK_SCHEME, parseDeepLink } from './deepLinks.ts';
+export { parseConnectionPayload, resultFromQrRaw } from './qr.ts';
+export {
+  canonicalRelayUrl,
+  connectionDisplayUrl,
+  getConnectionLabel,
+  isSameConnectionUrl,
+  lynxConnectionKey,
+  normalizeConnectionUrl,
+  relayConnectionRuntimeKey,
+  secureTokenKeyOf,
+} from './urls.ts';
+export { createLynxConnectionStore, migrateLegacyInlineTokens, prefixedTokenKey } from './store.ts';
+export { establishLiveTransport, pairingCandidatesToMobile, probeConnectionCandidates } from './probe.ts';
+export { createLynxConnectionController } from './controller.ts';
+export type { LynxConnectionController, LynxConnectionSnapshot } from './controller.ts';
+export { createLynxDeepLinkInbox } from './applyDeepLink.ts';
+export type { LynxApplyDeepLinkResult, LynxDeepLinkHandlers, LynxDeepLinkInbox } from './applyDeepLink.ts';
+export { sanitizeLogDetail } from './sanitizeLog.ts';
+export { refreshConnectionCandidates } from './candidates.ts';

--- a/packages/lynx/src/connect/pairing.test.ts
+++ b/packages/lynx/src/connect/pairing.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildPairingConnectionPayload,
+  encodePairingConnectionPayload,
+  parsePairingConnectionPayload,
+  parsePairingConnectionPayloadString,
+} from './pairing.ts';
+
+const hostEncPubJwk = { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' } as const;
+
+describe('pairing v2 payload', () => {
+  test('round-trips direct + relay candidates including relayUrl', () => {
+    const payload = buildPairingConnectionPayload({
+      pairingId: 'pair_123',
+      secret: 'one-time-secret',
+      label: 'Desktop',
+      fingerprint: 'ABCD-1234',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      candidates: [
+        { type: 'lan', url: 'http://192.168.1.20:4096/', priority: 20 },
+        { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv_abc', hostEncPubJwk, priority: 30 },
+      ],
+    });
+
+    const encoded = encodePairingConnectionPayload(payload);
+    expect(encoded.startsWith('openchamber://connect?v=2&p=')).toBe(true);
+    expect(parsePairingConnectionPayload(encoded)).toEqual({
+      ...payload,
+      candidates: [
+        { type: 'lan', url: 'http://192.168.1.20:4096', priority: 20 },
+        { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv_abc', hostEncPubJwk, priority: 30 },
+      ],
+    });
+  });
+
+  test('rejects legacy v1 connect links', () => {
+    expect(parsePairingConnectionPayload('openchamber://connect?v=1&server=https://runtime.example&token=t')).toBeNull();
+    expect(parsePairingConnectionPayload('openchamber://connect?v=2&p=not-json')).toBeNull();
+  });
+
+  test('rejects missing secret, file URLs, and expired payloads', () => {
+    const missingSecret = Buffer.from(JSON.stringify({
+      v: 2,
+      pairingId: 'pair_123',
+      candidates: [{ type: 'lan', url: 'http://runtime.example' }],
+    })).toString('base64url');
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${missingSecret}`)).toBeNull();
+
+    const invalidCandidate = Buffer.from(JSON.stringify({
+      v: 2,
+      pairingId: 'pair_123',
+      secret: 'secret',
+      candidates: [{ type: 'lan', url: 'file:///tmp/socket' }],
+    })).toString('base64url');
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${invalidCandidate}`)).toBeNull();
+
+    const expired = Buffer.from(JSON.stringify({
+      v: 2,
+      pairingId: 'pair_123',
+      secret: 'secret',
+      expiresAt: '2000-01-01T00:00:00.000Z',
+      candidates: [{ type: 'lan', url: 'http://runtime.example' }],
+    })).toString('base64url');
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${expired}`)).toBeNull();
+  });
+
+  test('string parser reads a v2 link without depending on URL hostname', () => {
+    const payload = buildPairingConnectionPayload({
+      pairingId: 'pair_old_webview',
+      secret: 'one-time-secret',
+      candidates: [{ type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 }],
+    });
+    const encoded = encodePairingConnectionPayload(payload);
+    expect(parsePairingConnectionPayloadString(encoded)?.pairingId).toBe('pair_old_webview');
+    expect(parsePairingConnectionPayloadString('openchamber://connect?v=1&p=abc')).toBeNull();
+  });
+
+  test('strips relay query/fragment and rejects userinfo', () => {
+    const encodeCandidates = (candidates: unknown[]) =>
+      Buffer.from(JSON.stringify({ v: 2, pairingId: 'pair_1', secret: 's', candidates })).toString('base64url');
+    const parsed = parsePairingConnectionPayload(`openchamber://connect?v=2&p=${encodeCandidates([{
+      type: 'relay',
+      relayUrl: 'wss://relay.example/ws?token=secret#frag',
+      serverId: 'srv',
+      hostEncPubJwk,
+    }])}`);
+    expect(parsed?.candidates).toEqual([
+      { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv', hostEncPubJwk },
+    ]);
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${encodeCandidates([{
+      type: 'relay',
+      relayUrl: 'wss://user:pass@relay.example/ws',
+      serverId: 'srv',
+      hostEncPubJwk,
+    }])}`)).toBeNull();
+  });
+});

--- a/packages/lynx/src/connect/pairing.ts
+++ b/packages/lynx/src/connect/pairing.ts
@@ -1,0 +1,213 @@
+/**
+ * Pairing v2 payload — official Cap contract from `packages/ui/src/lib/connectionPayload.ts`.
+ * Do not invent a redeem HTTP API. The client redeems on a reachable transport via
+ * `POST /api/client-auth/pairing/redeem`.
+ */
+
+import type { LynxPairingConnectionPayload, LynxPairingEndpointCandidate } from './types.ts';
+
+const MAX_PAIRING_PAYLOAD_LENGTH = 16_384;
+
+const globalWithBuffer = globalThis as typeof globalThis & {
+  Buffer?: {
+    from: (value: string, encoding?: string) => { toString: (encoding: string) => string };
+  };
+};
+
+const base64UrlEncode = (value: string): string => {
+  if (globalWithBuffer.Buffer) {
+    return globalWithBuffer.Buffer.from(value, 'utf8').toString('base64url');
+  }
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.slice(i, i + 0x8000));
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+const base64UrlDecode = (value: string): string | null => {
+  try {
+    if (globalWithBuffer.Buffer) {
+      return globalWithBuffer.Buffer.from(value, 'base64url').toString('utf8');
+    }
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(value.length / 4) * 4, '=');
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+};
+
+const normalizeHttpUrl = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    parsed.hash = '';
+    return parsed.toString().replace(/\/+$/g, '');
+  } catch {
+    return null;
+  }
+};
+
+const normalizeWsUrl = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') return null;
+    if (parsed.username || parsed.password) return null;
+    parsed.username = '';
+    parsed.password = '';
+    parsed.hash = '';
+    parsed.search = '';
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+};
+
+const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.length > 0;
+
+const normalizeEcPublicJwk = (value: unknown): JsonWebKey | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const jwk = value as Record<string, unknown>;
+  if (jwk.kty !== 'EC' || jwk.crv !== 'P-256') return null;
+  if (!isNonEmptyString(jwk.x) || !isNonEmptyString(jwk.y)) return null;
+  return { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y };
+};
+
+const normalizePriority = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+const normalizePairingCandidate = (value: unknown): LynxPairingEndpointCandidate | null => {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const priority = normalizePriority(record.priority);
+
+  if (record.type === 'lan' || record.type === 'tunnel') {
+    const url = normalizeHttpUrl(record.url);
+    if (!url) return null;
+    return priority === undefined ? { type: record.type, url } : { type: record.type, url, priority };
+  }
+
+  if (record.type === 'relay') {
+    const relayUrl = normalizeWsUrl(record.relayUrl);
+    if (!relayUrl) return null;
+    const serverId = typeof record.serverId === 'string' ? record.serverId.trim() : '';
+    if (!serverId) return null;
+    const hostEncPubJwk = normalizeEcPublicJwk(record.hostEncPubJwk);
+    if (!hostEncPubJwk) return null;
+    const grant = typeof record.grant === 'string' && record.grant.trim() ? record.grant.trim() : undefined;
+    return {
+      type: 'relay',
+      relayUrl,
+      serverId,
+      hostEncPubJwk,
+      ...(grant ? { grant } : {}),
+      ...(priority === undefined ? {} : { priority }),
+    };
+  }
+
+  return null;
+};
+
+const normalizePairingPayload = (value: unknown): LynxPairingConnectionPayload | null => {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (record.v !== 2) return null;
+  const pairingId = typeof record.pairingId === 'string' ? record.pairingId.trim() : '';
+  const secret = typeof record.secret === 'string' ? record.secret.trim() : '';
+  if (!pairingId || !secret) return null;
+  const candidates = Array.isArray(record.candidates)
+    ? record.candidates.map(normalizePairingCandidate).filter((candidate): candidate is LynxPairingEndpointCandidate => Boolean(candidate))
+    : [];
+  if (candidates.length === 0) return null;
+  const expiresAt = typeof record.expiresAt === 'string' && record.expiresAt.trim() ? record.expiresAt.trim() : undefined;
+  if (expiresAt) {
+    const expiresTime = Date.parse(expiresAt);
+    if (!Number.isFinite(expiresTime) || expiresTime <= Date.now()) return null;
+  }
+  const label = typeof record.label === 'string' && record.label.trim() ? record.label.trim() : undefined;
+  const fingerprint = typeof record.fingerprint === 'string' && record.fingerprint.trim() ? record.fingerprint.trim() : undefined;
+  return {
+    v: 2,
+    pairingId,
+    secret,
+    ...(label ? { label } : {}),
+    ...(fingerprint ? { fingerprint } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    candidates,
+  };
+};
+
+export const buildPairingConnectionPayload = (
+  input: Omit<LynxPairingConnectionPayload, 'v'>,
+): LynxPairingConnectionPayload => ({
+  v: 2,
+  pairingId: input.pairingId.trim(),
+  secret: input.secret.trim(),
+  ...(input.label?.trim() ? { label: input.label.trim() } : {}),
+  ...(input.fingerprint?.trim() ? { fingerprint: input.fingerprint.trim() } : {}),
+  ...(input.expiresAt?.trim() ? { expiresAt: input.expiresAt.trim() } : {}),
+  candidates: input.candidates,
+});
+
+export const encodePairingConnectionPayload = (payload: LynxPairingConnectionPayload): string => {
+  const normalized = normalizePairingPayload(payload);
+  if (!normalized) throw new Error('Invalid pairing connection payload');
+  const params = new URLSearchParams();
+  params.set('v', '2');
+  params.set('p', base64UrlEncode(JSON.stringify(normalized)));
+  return `openchamber://connect?${params.toString()}`;
+};
+
+export const parsePairingConnectionPayloadString = (value: string): LynxPairingConnectionPayload | null => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  const question = trimmed.indexOf('?');
+  if (question === -1 || !/^openchamber:\/\/connect\/?$/i.test(trimmed.slice(0, question))) return null;
+  let version: string | null = null;
+  let encoded: string | null = null;
+  for (const part of trimmed.slice(question + 1).split('&')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const key = part.slice(0, eq);
+    const raw = part.slice(eq + 1);
+    if (key === 'v') version = raw;
+    else if (key === 'p') encoded = raw;
+  }
+  if (version !== '2' || !encoded || encoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  const decoded = base64UrlDecode(encoded);
+  if (!decoded || decoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  try {
+    return normalizePairingPayload(JSON.parse(decoded) as unknown);
+  } catch {
+    return null;
+  }
+};
+
+export const parsePairingConnectionPayload = (value: string): LynxPairingConnectionPayload | null => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === 'openchamber:' && url.hostname === 'connect') {
+      if (url.searchParams.get('v') !== '2') return null;
+      const encoded = url.searchParams.get('p') || '';
+      if (!encoded || encoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+      const decoded = base64UrlDecode(encoded);
+      if (!decoded || decoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+      return normalizePairingPayload(JSON.parse(decoded) as unknown);
+    }
+  } catch {
+    // Fall through: some hosts throw or mis-parse this scheme.
+  }
+  return parsePairingConnectionPayloadString(trimmed);
+};

--- a/packages/lynx/src/connect/password.ts
+++ b/packages/lynx/src/connect/password.ts
@@ -1,0 +1,31 @@
+import type { LynxHostAdapters } from '../host/adapters.ts';
+import { jsonInit } from './http.ts';
+import { mobileClientDedupeKey } from './ids.ts';
+import { LYNX_CLIENT_KIND, LYNX_CLIENT_LABEL } from './types.ts';
+import type { LiveTransport } from './probe.ts';
+
+export const loginWithPasswordOnTransport = async (
+  transport: LiveTransport,
+  password: string,
+  host: LynxHostAdapters,
+  options: { deviceId: string; devicePlatform?: 'ios' | 'android' },
+): Promise<{ token: string } | null> => {
+  const body = {
+    password,
+    trustDevice: true,
+    issueClientToken: true,
+    clientLabel: LYNX_CLIENT_LABEL,
+    clientKind: LYNX_CLIENT_KIND,
+    devicePlatform: options.devicePlatform ?? host.devicePlatform,
+    dedupeKey: mobileClientDedupeKey(options.deviceId),
+  };
+  const init = jsonInit(body);
+  const response = transport.kind === 'relay'
+    ? await transport.tunnel.fetch('/auth/session', init).catch(() => null)
+    : await host.request(`${transport.url}/auth/session`, init).catch(() => null);
+  if (!response?.ok) return null;
+  const payload = await response.json().catch(() => null) as { clientToken?: unknown } | null;
+  const issuedToken = typeof payload?.clientToken === 'string' ? payload.clientToken.trim() : '';
+  if (!issuedToken) return null;
+  return { token: issuedToken };
+};

--- a/packages/lynx/src/connect/probe.test.ts
+++ b/packages/lynx/src/connect/probe.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+
+import { createMemoryClock, createMemoryHost, jsonResponse } from '../host/memory.ts';
+import { pairingCandidatesToMobile, probeConnectionCandidates } from './probe.ts';
+import { LYNX_RELAY_RACE_HEADSTART_MS } from './types.ts';
+
+const relay = {
+  relayUrl: 'wss://relay.example/ws',
+  serverId: 'srv_1',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' } as JsonWebKey,
+};
+
+describe('connect race', () => {
+  test('relay-only payloads do not sleep the LAN headstart', async () => {
+    const clock = createMemoryClock();
+    const host = createMemoryHost({
+      clock,
+      openRelay: async () => ({
+        fetch: async (path) => {
+          if (path === '/auth/session') return jsonResponse(200, { authenticated: true, scope: 'client' });
+          return jsonResponse(404, null);
+        },
+      }),
+    });
+
+    const result = await probeConnectionCandidates(
+      [{ kind: 'relay', relay }],
+      'tok',
+      host,
+    );
+    expect(result.status).toBe('ok');
+    expect(clock.sleeps).toEqual([]);
+  });
+
+  test('LAN + relay starts the 1.5s headstart and prefers a live LAN', async () => {
+    const clock = createMemoryClock();
+    let relayOpened = false;
+    const host = createMemoryHost({
+      clock,
+      request: async (url) => {
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok', serverId: 'srv_1' });
+        if (url.endsWith('/auth/session')) return jsonResponse(200, { authenticated: true, scope: 'client' });
+        return jsonResponse(404, null);
+      },
+      openRelay: async () => {
+        relayOpened = true;
+        return {
+          fetch: async () => jsonResponse(200, { authenticated: true, scope: 'client' }),
+        };
+      },
+    });
+
+    const probe = probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.9:2606' }, { kind: 'relay', relay }],
+      'tok',
+      host,
+    );
+    const result = await probe;
+    expect(result).toEqual({ status: 'ok', transport: { kind: 'direct', url: 'http://192.168.1.9:2606' } });
+    expect(clock.sleeps).toEqual([LYNX_RELAY_RACE_HEADSTART_MS]);
+    expect(relayOpened).toBe(false);
+  });
+
+  test('GET /health then /auth/session on a typed URL; 401 is needs-login', async () => {
+    const paths: string[] = [];
+    const host = createMemoryHost({
+      request: async (url) => {
+        paths.push(url.replace(/^https?:\/\/[^/]+/, ''));
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok' });
+        if (url.endsWith('/auth/session')) return jsonResponse(401, { authenticated: false });
+        return jsonResponse(404, null);
+      },
+    });
+    const result = await probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.9:2606' }],
+      'expired',
+      host,
+    );
+    expect(result.status).toBe('needs-login');
+    expect(paths).toEqual(['/health', '/auth/session']);
+  });
+
+  test('skips a LAN address whose /health serverId does not match the paired relay', async () => {
+    const host = createMemoryHost({
+      request: async (url) => {
+        if (url.endsWith('/health')) return jsonResponse(200, { status: 'ok', serverId: 'other' });
+        throw new Error('must not send bearer to a mismatched host');
+      },
+      openRelay: async () => ({
+        fetch: async () => jsonResponse(200, { authenticated: true, scope: 'client' }),
+      }),
+    });
+    const result = await probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.9:2606' }, { kind: 'relay', relay }],
+      'tok',
+      host,
+    );
+    expect(result).toEqual({ status: 'ok', transport: { kind: 'relay', relay } });
+  });
+});
+
+describe('pairingCandidatesToMobile', () => {
+  test('orders by priority and keeps relay last on ties', () => {
+    const candidates = pairingCandidatesToMobile([
+      { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv_1', hostEncPubJwk: relay.hostEncPubJwk, priority: 10 },
+      { type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 },
+      { type: 'tunnel', url: 'https://runtime.example', priority: 5 },
+    ]);
+    expect(candidates.map((candidate) => candidate.kind)).toEqual(['direct', 'direct', 'relay']);
+    expect(candidates[0] && candidates[0].kind === 'direct' ? candidates[0].url : '').toBe('https://runtime.example');
+  });
+});

--- a/packages/lynx/src/connect/probe.ts
+++ b/packages/lynx/src/connect/probe.ts
@@ -1,0 +1,279 @@
+import type { LynxHostAdapters } from '../host/adapters.ts';
+import { bearerHeaders, isAuthRejection, joinUrl, readHealthServerId, readSessionStatus } from './http.ts';
+import { safeLogInfo } from './sanitizeLog.ts';
+import {
+  LYNX_CONNECT_TIMEOUT_MS,
+  LYNX_FAST_PROBE_TIMEOUT_MS,
+  LYNX_RELAY_CONNECT_TIMEOUT_MS,
+  LYNX_RELAY_RACE_HEADSTART_MS,
+  type LynxHttpTransport,
+  type LynxProbeResult,
+  type LynxRelayConfig,
+  type LynxTransportCandidate,
+} from './types.ts';
+import { normalizeConnectionUrl, relayCandidateOf } from './urls.ts';
+
+export type LiveTransport =
+  | { kind: 'direct'; url: string }
+  | { kind: 'relay'; relay: LynxRelayConfig; tunnel: LynxHttpTransport };
+
+const timeoutFor = (fast?: boolean, relay?: boolean): number => {
+  if (fast) return LYNX_FAST_PROBE_TIMEOUT_MS;
+  return relay ? LYNX_RELAY_CONNECT_TIMEOUT_MS : LYNX_CONNECT_TIMEOUT_MS;
+};
+
+const defaultSleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+
+const probeDirect = async (
+  url: string,
+  token: string | undefined,
+  expectedServerId: string | null,
+  host: LynxHostAdapters,
+  timeoutMs: number,
+): Promise<LynxProbeResult> => {
+  const health = await host.request(joinUrl(url, '/health'), { method: 'GET', timeoutMs }).catch(() => null);
+  if (!health?.ok) return { status: 'unreachable' };
+  if (expectedServerId) {
+    const reported = await readHealthServerId(health);
+    if (reported && reported !== expectedServerId) {
+      safeLogInfo(host.logger, 'probe:server-id-mismatch', { url });
+      return { status: 'unreachable' };
+    }
+  }
+  const session = await host.request(joinUrl(url, '/auth/session'), {
+    method: 'GET',
+    headers: bearerHeaders(token),
+    timeoutMs,
+  }).catch(() => null);
+  if (session?.status === 401) return { status: 'needs-login' };
+  if (!session || (!session.ok && session.status !== 404)) return { status: 'unreachable' };
+  const status = await readSessionStatus(session);
+  if (isAuthRejection(status)) return { status: 'needs-login' };
+  const authDisabled = status?.disabled === true;
+  if (!token && !authDisabled && status?.scope !== 'client') return { status: 'needs-login' };
+  return { status: 'ok', transport: { kind: 'direct', url } };
+};
+
+const probeRelaySession = async (
+  relay: LynxRelayConfig,
+  token: string | undefined,
+  grant: string | undefined,
+  host: LynxHostAdapters,
+  timeoutMs: number,
+): Promise<LynxProbeResult> => {
+  if (!host.openRelay) return { status: 'unreachable' };
+  let tunnel: LynxHttpTransport | null = null;
+  try {
+    tunnel = await host.openRelay(relay, grant);
+    const session = await tunnel.fetch('/auth/session', {
+      method: 'GET',
+      headers: bearerHeaders(token),
+      timeoutMs,
+    }).catch(() => null);
+    safeLogInfo(host.logger, 'relay:session', {
+      ok: session?.ok === true,
+      status: session?.status ?? null,
+      hasToken: Boolean(token),
+    });
+    if (!session) return { status: 'unreachable' };
+    if (session.status === 401) return { status: token ? 'needs-login' : 'needs-login' };
+    if (!session.ok && session.status !== 404) return { status: 'needs-login' };
+    const status = await readSessionStatus(session);
+    if (status && status.disabled !== true && status.authenticated === false) {
+      return { status: token ? 'needs-login' : 'needs-login' };
+    }
+    return { status: 'ok', transport: { kind: 'relay', relay } };
+  } catch {
+    return { status: 'unreachable' };
+  } finally {
+    tunnel?.close?.();
+  }
+};
+
+export const probeConnectionCandidates = async (
+  candidates: LynxTransportCandidate[],
+  token: string | undefined,
+  host: LynxHostAdapters,
+  options?: { fast?: boolean; grant?: string },
+): Promise<LynxProbeResult> => {
+  const expectedServerId = relayCandidateOf({ candidates })?.serverId ?? null;
+  const relay = candidates.find((candidate): candidate is Extract<LynxTransportCandidate, { kind: 'relay' }> => candidate.kind === 'relay') ?? null;
+  const directs = candidates.filter((candidate): candidate is Extract<LynxTransportCandidate, { kind: 'direct' }> => candidate.kind === 'direct');
+  const timeoutMs = timeoutFor(options?.fast, false);
+  const relayTimeoutMs = timeoutFor(options?.fast, true);
+  const sleep = host.clock?.sleep ?? defaultSleep;
+
+  const probeDirectChain = async (): Promise<LynxProbeResult> => {
+    for (const candidate of directs) {
+      const url = normalizeConnectionUrl(candidate.url) || candidate.url;
+      const result = await probeDirect(url, token, expectedServerId, host, timeoutMs);
+      if (result.status !== 'unreachable') return result;
+    }
+    return { status: 'unreachable' };
+  };
+
+  const probeRelay = async (): Promise<LynxProbeResult> => {
+    if (!relay) return { status: 'unreachable' };
+    return probeRelaySession(relay.relay, token, options?.grant, host, relayTimeoutMs);
+  };
+
+  if (!relay) return probeDirectChain();
+  if (directs.length === 0) return probeRelay();
+
+  return new Promise<LynxProbeResult>((resolve) => {
+    let settled = false;
+    let relayCancelled = false;
+    let directResult: LynxProbeResult | null = null;
+    let relayResult: LynxProbeResult | null = null;
+    const abort = new AbortController();
+
+    const finish = (result: LynxProbeResult) => {
+      if (settled) return;
+      settled = true;
+      abort.abort();
+      resolve(result);
+    };
+
+    const startRelayProbe = () => {
+      if (relayCancelled || settled) return;
+      void probeRelay().then((result) => {
+        relayResult = result;
+        if (settled || relayCancelled) return;
+        if (result.status === 'ok' || result.status === 'needs-login') {
+          finish(result);
+          return;
+        }
+        if (directResult) finish(directResult);
+      });
+    };
+
+    void probeDirectChain().then((result) => {
+      directResult = result;
+      if (settled) return;
+      if (result.status === 'ok' || result.status === 'needs-login') {
+        relayCancelled = true;
+        finish(result);
+        return;
+      }
+      if (relayResult) {
+        finish(relayResult);
+        return;
+      }
+      startRelayProbe();
+    });
+
+    void sleep(LYNX_RELAY_RACE_HEADSTART_MS, abort.signal).then(() => {
+      if (!settled && !relayCancelled) startRelayProbe();
+    });
+  });
+};
+
+export const establishLiveTransport = async (
+  candidates: LynxTransportCandidate[],
+  host: LynxHostAdapters,
+  options?: { grant?: string },
+): Promise<LiveTransport | null> => {
+  const expectedServerId = relayCandidateOf({ candidates })?.serverId ?? null;
+  for (const candidate of candidates) {
+    if (candidate.kind === 'relay') {
+      if (!host.openRelay) continue;
+      let tunnel: LynxHttpTransport | null = null;
+      try {
+        tunnel = await host.openRelay(candidate.relay, options?.grant);
+        const health = await tunnel.fetch('/health', {
+          method: 'GET',
+          timeoutMs: LYNX_RELAY_CONNECT_TIMEOUT_MS,
+        }).catch(() => null);
+        safeLogInfo(host.logger, 'establish:relay:health', {
+          ok: health?.ok === true,
+          status: health?.status ?? null,
+        });
+        if (health?.ok) return { kind: 'relay', relay: candidate.relay, tunnel };
+        tunnel.close?.();
+      } catch {
+        tunnel?.close?.();
+      }
+      continue;
+    }
+    const url = normalizeConnectionUrl(candidate.url) || candidate.url;
+    const health = await host.request(joinUrl(url, '/health'), {
+      method: 'GET',
+      timeoutMs: LYNX_CONNECT_TIMEOUT_MS,
+    }).catch(() => null);
+    safeLogInfo(host.logger, 'establish:direct:health', {
+      ok: health?.ok === true,
+      status: health?.status ?? null,
+    });
+    if (!health?.ok) continue;
+    if (expectedServerId) {
+      const reported = await readHealthServerId(health);
+      if (reported && reported !== expectedServerId) {
+        safeLogInfo(host.logger, 'establish:server-id-mismatch', { url });
+        continue;
+      }
+    }
+    return { kind: 'direct', url };
+  }
+  return null;
+};
+
+export const validateDirectSession = async (
+  url: string,
+  token: string | undefined,
+  host: LynxHostAdapters,
+  options?: { fast?: boolean },
+): Promise<boolean> => {
+  const timeoutMs = timeoutFor(options?.fast, false);
+  const health = await host.request(joinUrl(url, '/health'), { method: 'GET', timeoutMs }).catch(() => null);
+  if (!health?.ok) return false;
+  const session = await host.request(joinUrl(url, '/auth/session'), {
+    method: 'GET',
+    headers: bearerHeaders(token),
+    timeoutMs,
+  }).catch(() => null);
+  if (!session || (!session.ok && session.status !== 404)) return false;
+  const status = await readSessionStatus(session);
+  return !isAuthRejection(status, session.status);
+};
+
+export const pairingCandidatesToMobile = (
+  candidates: Array<
+    | { type: 'lan' | 'tunnel'; url: string; priority?: number }
+    | { type: 'relay'; relayUrl: string; serverId: string; hostEncPubJwk: JsonWebKey; priority?: number }
+  >,
+): LynxTransportCandidate[] =>
+  [...candidates]
+    .sort((left, right) => {
+      const delta = (left.priority ?? 100) - (right.priority ?? 100);
+      if (delta !== 0) return delta;
+      const rank = (candidate: typeof left): number => {
+        if (candidate.type === 'relay') return 2;
+        return candidate.url.startsWith('https://') ? 0 : 1;
+      };
+      return rank(left) - rank(right);
+    })
+    .flatMap((candidate): LynxTransportCandidate[] => {
+      if (candidate.type === 'relay') {
+        return [{
+          kind: 'relay',
+          relay: {
+            relayUrl: candidate.relayUrl,
+            serverId: candidate.serverId,
+            hostEncPubJwk: candidate.hostEncPubJwk,
+          },
+        }];
+      }
+      try {
+        const url = normalizeConnectionUrl(candidate.url);
+        return url ? [{ kind: 'direct', url }] : [];
+      } catch {
+        return [];
+      }
+    });

--- a/packages/lynx/src/connect/qr.ts
+++ b/packages/lynx/src/connect/qr.ts
@@ -1,0 +1,45 @@
+/**
+ * QR / paste parse for connect. Camera is a host adapter — this module only
+ * interprets the raw string. No Nearby / Bonjour browse.
+ */
+
+import { parsePairingConnectionPayload } from './pairing.ts';
+import type { LynxConnectError, LynxPairingConnectionPayload } from './types.ts';
+
+export type LynxConnectionPayload =
+  | { kind: 'url'; url: string; clientToken?: string; label?: string }
+  | { kind: 'pairing'; pairing: LynxPairingConnectionPayload };
+
+export type LynxQrParseResult =
+  | ({ status: 'ok' } & Extract<LynxConnectionPayload, { kind: 'url' }>)
+  | ({ status: 'pairing' } & Extract<LynxConnectionPayload, { kind: 'pairing' }>)
+  | { status: 'invalid' };
+
+export const parseConnectionPayload = (raw: string): LynxConnectionPayload | null => {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (/^openchamber:\/\//i.test(trimmed)) {
+    const pairing = parsePairingConnectionPayload(trimmed);
+    return pairing ? { kind: 'pairing', pairing } : null;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) return { kind: 'url', url: trimmed };
+  return null;
+};
+
+export const resultFromQrRaw = (raw: string): LynxQrParseResult => {
+  const payload = parseConnectionPayload(raw);
+  if (!payload) return { status: 'invalid' };
+  if (payload.kind === 'pairing') return { status: 'pairing', ...payload };
+  return { status: 'ok', ...payload };
+};
+
+export const qrScanStatusToError = (
+  status: 'permission-denied' | 'unsupported' | 'failed' | 'invalid',
+): LynxConnectError => {
+  if (status === 'permission-denied') return 'scan-permission-denied';
+  if (status === 'unsupported') return 'scan-unsupported';
+  if (status === 'failed') return 'scan-failed';
+  return 'scan-invalid';
+};

--- a/packages/lynx/src/connect/redeem.ts
+++ b/packages/lynx/src/connect/redeem.ts
@@ -1,0 +1,39 @@
+import type { LynxHostAdapters } from '../host/adapters.ts';
+import { jsonInit } from './http.ts';
+import { mobileClientDedupeKey } from './ids.ts';
+import { LYNX_CLIENT_KIND, LYNX_CLIENT_LABEL, type LynxPairingConnectionPayload } from './types.ts';
+import type { LiveTransport } from './probe.ts';
+
+export type PairingRedeemResponse = {
+  ok?: boolean;
+  clientToken?: unknown;
+  client?: { label?: unknown } | null;
+  server?: { label?: unknown; url?: unknown } | null;
+};
+
+export const redeemPairingOnTransport = async (
+  transport: LiveTransport,
+  payload: LynxPairingConnectionPayload,
+  host: LynxHostAdapters,
+  options: { deviceId: string; devicePlatform?: 'ios' | 'android' },
+): Promise<{ token: string; serverLabel: string } | null> => {
+  const body = {
+    pairingId: payload.pairingId,
+    secret: payload.secret,
+    clientLabel: LYNX_CLIENT_LABEL,
+    clientKind: LYNX_CLIENT_KIND,
+    deviceName: LYNX_CLIENT_LABEL,
+    devicePlatform: options.devicePlatform ?? host.devicePlatform,
+    dedupeKey: mobileClientDedupeKey(options.deviceId),
+  };
+  const init = jsonInit(body);
+  const response = transport.kind === 'relay'
+    ? await transport.tunnel.fetch('/api/client-auth/pairing/redeem', init).catch(() => null)
+    : await host.request(`${transport.url}/api/client-auth/pairing/redeem`, init).catch(() => null);
+  if (!response?.ok) return null;
+  const result = await response.json().catch(() => null) as PairingRedeemResponse | null;
+  const issuedToken = typeof result?.clientToken === 'string' ? result.clientToken.trim() : '';
+  if (!issuedToken) return null;
+  const serverLabel = typeof result?.server?.label === 'string' ? result.server.label : '';
+  return { token: issuedToken, serverLabel };
+};

--- a/packages/lynx/src/connect/sanitizeLog.test.ts
+++ b/packages/lynx/src/connect/sanitizeLog.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { sanitizeLogDetail } from './sanitizeLog.ts';
+
+describe('sanitizeLogDetail', () => {
+  test('never forwards tokens, pairing secrets, passwords, or grants', () => {
+    expect(sanitizeLogDetail({
+      hasToken: true,
+      clientToken: 'oc_live_secret',
+      secret: 'one-time',
+      password: 'hunter2',
+      grant: 'relay-grant',
+      Authorization: 'Bearer abc',
+      status: 200,
+    })).toEqual({
+      hasToken: true,
+      clientToken: '[redacted]',
+      secret: '[redacted]',
+      password: '[redacted]',
+      grant: '[redacted]',
+      Authorization: '[redacted]',
+      status: 200,
+    });
+  });
+});

--- a/packages/lynx/src/connect/sanitizeLog.ts
+++ b/packages/lynx/src/connect/sanitizeLog.ts
@@ -1,0 +1,42 @@
+const SECRET_KEY = /^(token|clienttoken|secret|password|authorization|grant|bearertoken|pairingsecret)$/i;
+const SECRET_SUFFIX = /(token|secret|password|authorization|grant|bearer)$/i;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const isSecretKey = (key: string): boolean => {
+  if (key.toLowerCase() === 'hastoken') return false;
+  return SECRET_KEY.test(key) || SECRET_SUFFIX.test(key);
+};
+
+const redactValue = (key: string, value: unknown): unknown => {
+  if (isSecretKey(key)) return '[redacted]';
+  if (Array.isArray(value)) return value.map((entry) => redactValue(key, entry));
+  if (isPlainObject(value)) return sanitizeLogDetail(value);
+  return value;
+};
+
+/** Strip bearer tokens, pairing secrets, passwords, and grants from log details. */
+export const sanitizeLogDetail = (detail: Record<string, unknown> = {}): Record<string, unknown> => {
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(detail)) {
+    next[key] = redactValue(key, value);
+  }
+  return next;
+};
+
+export const safeLogInfo = (
+  logger: { info: (step: string, detail?: Record<string, unknown>) => void } | undefined,
+  step: string,
+  detail?: Record<string, unknown>,
+): void => {
+  logger?.info(step, detail ? sanitizeLogDetail(detail) : undefined);
+};
+
+export const safeLogWarn = (
+  logger: { warn: (step: string, detail?: Record<string, unknown>) => void } | undefined,
+  step: string,
+  detail?: Record<string, unknown>,
+): void => {
+  logger?.warn(step, detail ? sanitizeLogDetail(detail) : undefined);
+};

--- a/packages/lynx/src/connect/store.test.ts
+++ b/packages/lynx/src/connect/store.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest';
+
+import { createMemoryJsonStore, createMemorySecureStore } from '../host/memory.ts';
+import {
+  createLynxConnectionStore,
+  migrateLegacyInlineTokens,
+  prefixedTokenKey,
+} from './store.ts';
+import { LYNX_METADATA_STORAGE_KEY } from './types.ts';
+import { secureTokenKeyOf } from './urls.ts';
+
+const testRelay = {
+  relayUrl: 'wss://relay.example/tunnel',
+  serverId: 'srv_test123',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' } as JsonWebKey,
+};
+
+describe('instance persistence', () => {
+  test('persists the full LAN + relay candidate set including v2 relayUrl', () => {
+    const metadata = createMemoryJsonStore();
+    const store = createLynxConnectionStore(metadata);
+    store.upsert({
+      label: 'Both',
+      candidates: [
+        { kind: 'direct', url: 'http://192.168.1.5:2606' },
+        { kind: 'relay', relay: testRelay },
+      ],
+      hasToken: true,
+      now: 10,
+      createId: () => 'conn_1',
+    });
+
+    const loaded = store.load();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.candidates).toEqual([
+      { kind: 'direct', url: 'http://192.168.1.5:2606' },
+      { kind: 'relay', relay: testRelay },
+    ]);
+
+    const raw = JSON.parse(metadata.read(LYNX_METADATA_STORAGE_KEY) || '[]') as Array<Record<string, unknown>>;
+    expect(raw[0]?.clientToken).toBeUndefined();
+    const rawCandidate = (raw[0]?.candidates as Array<Record<string, unknown>>)[1];
+    expect(rawCandidate.kind).toBe('relay');
+    expect(Object.keys(rawCandidate.relay as object).sort()).toEqual(['hostEncPubJwk', 'relayUrl', 'serverId']);
+  });
+
+  test('migrates a pre-candidates URL entry and drops a broken relay', () => {
+    const metadata = createMemoryJsonStore({
+      [LYNX_METADATA_STORAGE_KEY]: JSON.stringify([
+        { id: 'bad', label: 'Broken', lastUsedAt: 20, mode: 'relay', relay: { relayUrl: 'wss://relay.example' } },
+        { id: 'ok', label: 'Home', url: 'http://192.168.1.10:2606', lastUsedAt: 10, clientToken: 'legacy' },
+      ]),
+    });
+    const store = createLynxConnectionStore(metadata);
+    const loaded = store.load();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.id).toBe('ok');
+    expect(loaded[0]?.candidates).toEqual([{ kind: 'direct', url: 'http://192.168.1.10:2606' }]);
+    expect(loaded[0]?.hasToken).toBe(true);
+  });
+
+  test('same serverId on a different relayUrl stays a separate instance', () => {
+    const store = createLynxConnectionStore(createMemoryJsonStore());
+    store.upsert({ label: 'Stable', candidates: [{ kind: 'relay', relay: testRelay }], now: 1, createId: () => 'a' });
+    store.upsert({
+      label: 'Preview',
+      candidates: [{ kind: 'relay', relay: { ...testRelay, relayUrl: 'wss://self-hosted.example/ws' } }],
+      now: 2,
+      createId: () => 'b',
+    });
+    expect(store.load().map((connection) => connection.label).sort()).toEqual(['Preview', 'Stable']);
+  });
+
+  test('moves an inline legacy token into the secure store and strips metadata', async () => {
+    const metadata = createMemoryJsonStore({
+      [LYNX_METADATA_STORAGE_KEY]: JSON.stringify([
+        { id: 'a', label: 'Home', url: 'http://192.168.1.10:2606', lastUsedAt: 10, clientToken: 'tok-a' },
+      ]),
+    });
+    const secure = createMemorySecureStore();
+    await migrateLegacyInlineTokens(metadata, secure);
+    const store = createLynxConnectionStore(metadata);
+    const loaded = store.load();
+    expect(loaded[0]?.hasToken).toBe(true);
+    const raw = JSON.parse(metadata.read(LYNX_METADATA_STORAGE_KEY) || '[]') as Array<Record<string, unknown>>;
+    expect(raw[0]?.clientToken).toBeUndefined();
+    const key = prefixedTokenKey(secureTokenKeyOf(loaded[0]!));
+    expect(secure.snapshot()[key]).toBe('tok-a');
+  });
+});

--- a/packages/lynx/src/connect/store.ts
+++ b/packages/lynx/src/connect/store.ts
@@ -1,0 +1,206 @@
+import type { LynxJsonStore, LynxSecureStore } from '../host/adapters.ts';
+import { createLynxId } from './ids.ts';
+import {
+  LYNX_CONNECTIONS_LIMIT,
+  LYNX_METADATA_STORAGE_KEY,
+  LYNX_SECURE_TOKEN_PREFIX,
+  type LynxSavedConnection,
+  type LynxTransportCandidate,
+} from './types.ts';
+import {
+  candidateSetsMatch,
+  connectionDisplayUrl,
+  getConnectionLabel,
+  normalizeConnectionUrl,
+  parseRelayConfig,
+  secureTokenKeyOf,
+  serializeCandidate,
+} from './urls.ts';
+
+export const prefixedTokenKey = (key: string): string =>
+  `${LYNX_SECURE_TOKEN_PREFIX}${encodeURIComponent(key)}`;
+
+const parseCandidate = (value: unknown): LynxTransportCandidate | null => {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.kind === 'direct') {
+    return typeof candidate.url === 'string' && candidate.url.trim()
+      ? { kind: 'direct', url: candidate.url }
+      : null;
+  }
+  if (candidate.kind === 'relay') {
+    const relay = parseRelayConfig(candidate.relay);
+    return relay ? { kind: 'relay', relay } : null;
+  }
+  return null;
+};
+
+const migrateLegacyCandidates = (record: Record<string, unknown>): LynxTransportCandidate[] => {
+  if (record.mode === 'relay') {
+    const relay = parseRelayConfig(record.relay);
+    return relay ? [{ kind: 'relay', relay }] : [];
+  }
+  if (typeof record.url !== 'string') return [];
+  try {
+    const url = normalizeConnectionUrl(record.url);
+    return url ? [{ kind: 'direct', url }] : [];
+  } catch {
+    return [];
+  }
+};
+
+const parseSavedConnections = (raw: string | null): LynxSavedConnection[] => {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .flatMap((item): LynxSavedConnection[] => {
+      if (!item || typeof item !== 'object') return [];
+      const record = item as Record<string, unknown>;
+      if (typeof record.id !== 'string') return [];
+      const candidates = Array.isArray(record.candidates)
+        ? record.candidates.map(parseCandidate).filter((candidate): candidate is LynxTransportCandidate => Boolean(candidate))
+        : migrateLegacyCandidates(record);
+      if (candidates.length === 0) return [];
+      const inlineToken = typeof record.clientToken === 'string' && record.clientToken.trim() ? record.clientToken : undefined;
+      const label = typeof record.label === 'string' && record.label.trim()
+        ? record.label
+        : getConnectionLabel(connectionDisplayUrl({ candidates }));
+      return [{
+        id: record.id,
+        label,
+        candidates,
+        lastUsedAt: typeof record.lastUsedAt === 'number' ? record.lastUsedAt : 0,
+        hasToken: Boolean(record.hasToken) || Boolean(inlineToken),
+      }];
+    })
+    .sort((left, right) => right.lastUsedAt - left.lastUsedAt);
+};
+
+const serializeConnections = (connections: LynxSavedConnection[]): string =>
+  JSON.stringify(connections.slice(0, LYNX_CONNECTIONS_LIMIT).map((connection) => ({
+    id: connection.id,
+    label: connection.label,
+    candidates: connection.candidates.map(serializeCandidate),
+    lastUsedAt: connection.lastUsedAt,
+    hasToken: Boolean(connection.hasToken),
+  })));
+
+export type LynxConnectionStore = {
+  load: () => LynxSavedConnection[];
+  write: (connections: LynxSavedConnection[]) => void;
+  upsert: (draft: {
+    id?: string;
+    label: string;
+    candidates: LynxTransportCandidate[];
+    hasToken?: boolean;
+    now?: number;
+    createId?: () => string;
+  }) => LynxSavedConnection[];
+  remove: (id: string) => { next: LynxSavedConnection[]; removed: LynxSavedConnection | null };
+};
+
+export const createLynxConnectionStore = (metadataStore: LynxJsonStore): LynxConnectionStore => {
+  const load = (): LynxSavedConnection[] => parseSavedConnections(metadataStore.read(LYNX_METADATA_STORAGE_KEY));
+
+  const write = (connections: LynxSavedConnection[]): void => {
+    metadataStore.write(LYNX_METADATA_STORAGE_KEY, serializeConnections(connections));
+  };
+
+  const upsert: LynxConnectionStore['upsert'] = (draft) => {
+    const connections = load();
+    const existing = connections.find((item) => (
+      (draft.id && item.id === draft.id) || candidateSetsMatch(item.candidates, draft.candidates)
+    ));
+    const nextEntry: LynxSavedConnection = {
+      id: draft.id || existing?.id || (draft.createId ?? createLynxId)(),
+      label: draft.label,
+      candidates: draft.candidates,
+      lastUsedAt: draft.now ?? Date.now(),
+      hasToken: draft.hasToken ?? existing?.hasToken ?? false,
+    };
+    const next = [
+      nextEntry,
+      ...connections.filter((item) => item.id !== nextEntry.id && !candidateSetsMatch(item.candidates, draft.candidates)),
+    ].slice(0, LYNX_CONNECTIONS_LIMIT);
+    write(next);
+    return next;
+  };
+
+  const remove = (id: string) => {
+    const connections = load();
+    const removed = connections.find((connection) => connection.id === id) ?? null;
+    const next = connections.filter((connection) => connection.id !== id);
+    write(next);
+    return { next, removed };
+  };
+
+  return { load, write, upsert, remove };
+};
+
+export const readSecureToken = async (
+  secureStore: LynxSecureStore,
+  connection: { candidates: LynxTransportCandidate[] },
+): Promise<string | undefined> => {
+  const key = secureTokenKeyOf(connection);
+  if (!key) return undefined;
+  const token = await secureStore.getToken(prefixedTokenKey(key));
+  return typeof token === 'string' && token.trim() ? token : undefined;
+};
+
+export const writeSecureToken = async (
+  secureStore: LynxSecureStore,
+  connection: { candidates: LynxTransportCandidate[] },
+  token: string,
+): Promise<boolean> => {
+  const key = secureTokenKeyOf(connection);
+  if (!key) return false;
+  return secureStore.setToken(prefixedTokenKey(key), token);
+};
+
+export const deleteSecureToken = async (
+  secureStore: LynxSecureStore,
+  connection: { candidates: LynxTransportCandidate[] },
+): Promise<void> => {
+  const key = secureTokenKeyOf(connection);
+  if (!key) return;
+  await secureStore.deleteToken(prefixedTokenKey(key));
+};
+
+/** Move an inline legacy `clientToken` from metadata into the secure store. */
+export const migrateLegacyInlineTokens = async (
+  metadataStore: LynxJsonStore,
+  secureStore: LynxSecureStore,
+): Promise<void> => {
+  const raw = metadataStore.read(LYNX_METADATA_STORAGE_KEY);
+  if (!raw) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  let moved = false;
+  for (const item of parsed) {
+    if (!item || typeof item !== 'object') continue;
+    const record = item as Record<string, unknown>;
+    const token = typeof record.clientToken === 'string' ? record.clientToken.trim() : '';
+    if (!token) continue;
+    const candidates = Array.isArray(record.candidates)
+      ? record.candidates.map(parseCandidate).filter((candidate): candidate is LynxTransportCandidate => Boolean(candidate))
+      : migrateLegacyCandidates(record);
+    if (candidates.length === 0) continue;
+    await writeSecureToken(secureStore, { candidates }, token);
+    moved = true;
+  }
+  if (!moved) return;
+  const store = createLynxConnectionStore(metadataStore);
+  const cleaned = store.load().map((connection) => ({ ...connection, hasToken: true }));
+  store.write(cleaned);
+};

--- a/packages/lynx/src/connect/types.ts
+++ b/packages/lynx/src/connect/types.ts
@@ -1,0 +1,168 @@
+/**
+ * Lynx connect types. Transport and pairing shapes match Capacitor
+ * `mobileConnections.ts` / `connectionPayload.ts` so a Lynx host can persist
+ * the same LAN+relay candidate set and redeem the same v2 payload.
+ */
+
+export type LynxConnectionMode = 'direct' | 'relay';
+
+export type LynxRelayConfig = {
+  relayUrl: string;
+  serverId: string;
+  hostEncPubJwk: JsonWebKey;
+};
+
+export type LynxTransportCandidate =
+  | { kind: 'direct'; url: string }
+  | { kind: 'relay'; relay: LynxRelayConfig };
+
+export type LynxSavedConnection = {
+  id: string;
+  label: string;
+  candidates: LynxTransportCandidate[];
+  lastUsedAt: number;
+  hasToken: boolean;
+};
+
+export type LynxPendingConnection = {
+  id: string;
+  label: string;
+  candidates: LynxTransportCandidate[];
+  relay?: LynxRelayConfig;
+  relayGrant?: string;
+};
+
+export type LynxConnectInput = {
+  id?: string;
+  url?: string;
+  candidates?: LynxTransportCandidate[];
+  clientToken?: string;
+  label?: string;
+  relay?: LynxRelayConfig;
+  relayGrant?: string;
+};
+
+export type LynxChosenTransport =
+  | { kind: 'direct'; url: string }
+  | { kind: 'relay'; relay: LynxRelayConfig };
+
+export type LynxRuntimeBind = {
+  runtimeKey: string;
+  transport: LynxChosenTransport;
+  clientToken: string | null;
+};
+
+export type LynxConnectError =
+  | 'url-required'
+  | 'invalid-url'
+  | 'unreachable'
+  | 'auth-required'
+  | 'password-failed'
+  | 'pairing-invalid'
+  | 'pairing-expired'
+  | 'scan-permission-denied'
+  | 'scan-invalid'
+  | 'scan-unsupported'
+  | 'scan-failed'
+  | 'secure-store-failed';
+
+export type LynxConnectPhase = 'resolving' | 'welcome' | 'password' | 'connected';
+
+export type LynxHttpInit = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs?: number;
+};
+
+export type LynxHttpResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+};
+
+export type LynxHttpTransport = {
+  fetch: (path: string, init?: LynxHttpInit) => Promise<LynxHttpResponse>;
+  close?: () => void;
+};
+
+export type LynxQrScanRaw =
+  | { status: 'ok'; raw: string }
+  | { status: 'cancelled' }
+  | { status: 'permission-denied' }
+  | { status: 'unsupported' }
+  | { status: 'failed' };
+
+export type LynxDevicePlatform = 'ios' | 'android';
+
+export type LynxSessionStatus = {
+  authenticated?: boolean;
+  disabled?: boolean;
+  scope?: string;
+  serverId?: string;
+};
+
+export type LynxPairingDirectCandidate = {
+  type: 'lan' | 'tunnel';
+  url: string;
+  priority?: number;
+};
+
+export type LynxPairingRelayCandidate = {
+  type: 'relay';
+  relayUrl: string;
+  serverId: string;
+  hostEncPubJwk: JsonWebKey;
+  grant?: string;
+  priority?: number;
+};
+
+export type LynxPairingEndpointCandidate = LynxPairingDirectCandidate | LynxPairingRelayCandidate;
+
+export type LynxPairingConnectionPayload = {
+  v: 2;
+  pairingId: string;
+  secret: string;
+  label?: string;
+  fingerprint?: string;
+  expiresAt?: string;
+  candidates: LynxPairingEndpointCandidate[];
+};
+
+export type LynxSessionsFilter = 'all' | 'attention' | 'recent';
+export type LynxViewTarget = 'files' | 'mcp' | 'instances' | 'update';
+
+export type LynxDeepLinkIntent =
+  | { type: 'connect'; pairing: LynxPairingConnectionPayload }
+  | { type: 'session'; sessionId: string; directory?: string }
+  | { type: 'new-session'; directory?: string; projectId?: string; agent?: string; model?: string; prompt?: string }
+  | { type: 'open-project'; directory: string }
+  | { type: 'sessions'; filter?: LynxSessionsFilter }
+  | { type: 'status' }
+  | { type: 'settings'; section?: string }
+  | { type: 'changes'; path?: string; staged?: boolean }
+  | { type: 'view'; target: LynxViewTarget };
+
+export type LynxProbeResult =
+  | { status: 'ok'; transport: LynxChosenTransport }
+  | { status: 'needs-login' }
+  | { status: 'unreachable' };
+
+export type LynxReprobeOutcome = 'switched' | 'unchanged' | 'unreachable' | 'no-connection';
+
+export type LynxCandidateRefreshResult = 'updated' | 'unchanged' | 'skipped';
+
+export const LYNX_CONNECTIONS_LIMIT = 12;
+export const LYNX_CONNECT_TIMEOUT_MS = 8_000;
+export const LYNX_RELAY_CONNECT_TIMEOUT_MS = 15_000;
+export const LYNX_FAST_PROBE_TIMEOUT_MS = 2_500;
+export const LYNX_RELAY_RACE_HEADSTART_MS = 1_500;
+export const LYNX_CANDIDATE_REFRESH_DELAY_MS = 5_000;
+export const LYNX_SECURE_TIMEOUT_MS = 3_000;
+
+export const LYNX_METADATA_STORAGE_KEY = 'openchamber.mobile.connections.v1';
+export const LYNX_DEVICE_ID_STORAGE_KEY = 'openchamber.mobile.deviceId';
+export const LYNX_SECURE_TOKEN_PREFIX = 'openchamber.mobile.token.';
+
+export const LYNX_CLIENT_LABEL = 'OpenChamber Mobile';
+export const LYNX_CLIENT_KIND = 'mobile';

--- a/packages/lynx/src/connect/urls.ts
+++ b/packages/lynx/src/connect/urls.ts
@@ -1,0 +1,108 @@
+import type { LynxRelayConfig, LynxTransportCandidate } from './types.ts';
+
+export const normalizeConnectionUrl = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  const url = new URL(withScheme);
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/+$/, '');
+};
+
+export const getConnectionLabel = (url: string): string => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+};
+
+const getConnectionStorageKey = (url: string): string => {
+  try {
+    return normalizeConnectionUrl(url);
+  } catch {
+    return url.trim().replace(/\/+$/g, '');
+  }
+};
+
+export const isSameConnectionUrl = (left: string, right: string): boolean =>
+  getConnectionStorageKey(left) === getConnectionStorageKey(right);
+
+export const relayConnectionRuntimeKey = (relay: LynxRelayConfig): string =>
+  `relay:${relay.serverId}@${relay.relayUrl.trim()}`;
+
+export const canonicalRelayUrl = (relay: LynxRelayConfig): string => `relay://${relay.serverId}`;
+
+export const directCandidates = (
+  connection: { candidates: LynxTransportCandidate[] },
+): Array<{ kind: 'direct'; url: string }> =>
+  connection.candidates.filter((candidate): candidate is { kind: 'direct'; url: string } => candidate.kind === 'direct');
+
+export const relayCandidateOf = (
+  connection: { candidates: LynxTransportCandidate[] },
+): LynxRelayConfig | null => {
+  const found = connection.candidates.find((candidate) => candidate.kind === 'relay');
+  return found && found.kind === 'relay' ? found.relay : null;
+};
+
+export const connectionDisplayUrl = (connection: { candidates: LynxTransportCandidate[] }): string => {
+  const direct = directCandidates(connection)[0];
+  if (direct) return direct.url;
+  const relay = relayCandidateOf(connection);
+  return relay ? canonicalRelayUrl(relay) : '';
+};
+
+export const secureTokenKeyOf = (connection: { candidates: LynxTransportCandidate[] }): string => {
+  const relay = relayCandidateOf(connection);
+  if (relay) return relayConnectionRuntimeKey(relay);
+  const direct = directCandidates(connection)[0];
+  return direct ? getConnectionStorageKey(direct.url) : '';
+};
+
+export const lynxConnectionKey = secureTokenKeyOf;
+
+export const parseRelayConfig = (value: unknown): LynxRelayConfig | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.relayUrl !== 'string' || !record.relayUrl.trim()) return null;
+  if (typeof record.serverId !== 'string' || !record.serverId.trim()) return null;
+  const jwk = record.hostEncPubJwk;
+  if (!jwk || typeof jwk !== 'object' || Array.isArray(jwk)) return null;
+  const key = jwk as Record<string, unknown>;
+  if (key.kty !== 'EC' || key.crv !== 'P-256') return null;
+  if (typeof key.x !== 'string' || !key.x || typeof key.y !== 'string' || !key.y) return null;
+  return {
+    relayUrl: record.relayUrl,
+    serverId: record.serverId,
+    hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: key.x, y: key.y },
+  };
+};
+
+export const candidateSetsMatch = (left: LynxTransportCandidate[], right: LynxTransportCandidate[]): boolean => {
+  const leftRelay = left.find((candidate) => candidate.kind === 'relay');
+  const leftServerId = leftRelay && leftRelay.kind === 'relay' ? leftRelay.relay.serverId : null;
+  const leftRelayUrl = leftRelay && leftRelay.kind === 'relay' ? leftRelay.relay.relayUrl.trim() : null;
+  const leftUrls = new Set(
+    left.filter((candidate) => candidate.kind === 'direct').map((candidate) => getConnectionStorageKey(candidate.url)),
+  );
+  return right.some((candidate) => {
+    if (candidate.kind === 'relay') {
+      return leftServerId !== null && candidate.relay.serverId === leftServerId && candidate.relay.relayUrl.trim() === leftRelayUrl;
+    }
+    return leftUrls.has(getConnectionStorageKey(candidate.url));
+  });
+};
+
+export const serializeCandidate = (candidate: LynxTransportCandidate): unknown =>
+  candidate.kind === 'relay'
+    ? {
+        kind: 'relay',
+        relay: {
+          relayUrl: candidate.relay.relayUrl,
+          serverId: candidate.relay.serverId,
+          hostEncPubJwk: candidate.relay.hostEncPubJwk,
+        },
+      }
+    : { kind: 'direct', url: candidate.url };

--- a/packages/lynx/src/host/adapters.ts
+++ b/packages/lynx/src/host/adapters.ts
@@ -1,0 +1,63 @@
+import type {
+  LynxDevicePlatform,
+  LynxHttpInit,
+  LynxHttpResponse,
+  LynxHttpTransport,
+  LynxQrScanRaw,
+  LynxRelayConfig,
+  LynxRuntimeBind,
+} from '../connect/types.ts';
+
+/**
+ * Host adapters the Lynx shell (or a test) injects into the connect kernel.
+ *
+ * Integration point: a future iOS/Android Lynx host implements these and calls
+ * `createLynxConnectionController`. There is no Lynx app package yet.
+ *
+ * - `request` — native HTTP to a LAN/tunnel URL (ATS/cleartext as the host allows).
+ * - `openRelay` — open the official E2EE relay tunnel, then HTTP over it.
+ *   Do not invent a redeem URL; redeem still hits `/api/client-auth/pairing/redeem`.
+ * - `secureStore` — Keychain / Keystore. Tokens never enter metadata storage.
+ * - `scanQr` — optional camera. Parsing is in the kernel; the host only returns raw text.
+ * - `bindRuntime` — switch the shell's active OpenChamber origin + bearer.
+ */
+export type LynxSecureStore = {
+  getToken: (key: string) => Promise<string | undefined>;
+  setToken: (key: string, token: string) => Promise<boolean>;
+  deleteToken: (key: string) => Promise<void>;
+};
+
+export type LynxJsonStore = {
+  read: (key: string) => string | null;
+  write: (key: string, value: string) => void;
+  remove?: (key: string) => void;
+};
+
+export type LynxClock = {
+  now: () => number;
+  sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
+};
+
+export type LynxLogger = {
+  info: (step: string, detail?: Record<string, unknown>) => void;
+  warn: (step: string, detail?: Record<string, unknown>) => void;
+};
+
+export type LynxHostAdapters = {
+  request: (url: string, init?: LynxHttpInit) => Promise<LynxHttpResponse>;
+  openRelay?: (relay: LynxRelayConfig, grant?: string) => Promise<LynxHttpTransport>;
+  /** Authenticated fetch on the already-bound runtime (direct or relay). */
+  runtimeFetch?: (path: string, init?: LynxHttpInit) => Promise<LynxHttpResponse>;
+  secureStore: LynxSecureStore;
+  metadataStore: LynxJsonStore;
+  clock?: LynxClock;
+  logger?: LynxLogger;
+  createId?: () => string;
+  devicePlatform?: LynxDevicePlatform;
+  bindRuntime?: (bind: LynxRuntimeBind) => void;
+  scanQr?: () => Promise<LynxQrScanRaw>;
+  /** Bound runtime identity, used by resume re-probe. */
+  getRuntimeKey?: () => string | null;
+  isRelayModeActive?: () => boolean;
+  getRuntimeDirectUrl?: () => string | null;
+};

--- a/packages/lynx/src/host/memory.ts
+++ b/packages/lynx/src/host/memory.ts
@@ -1,0 +1,123 @@
+import type { LynxHostAdapters, LynxJsonStore, LynxSecureStore } from './adapters.ts';
+import type { LynxHttpInit, LynxHttpResponse, LynxHttpTransport, LynxRelayConfig } from '../connect/types.ts';
+
+export const createMemoryJsonStore = (initial: Record<string, string> = {}): LynxJsonStore => {
+  const map = new Map(Object.entries(initial));
+  return {
+    read: (key) => map.get(key) ?? null,
+    write: (key, value) => {
+      map.set(key, value);
+    },
+    remove: (key) => {
+      map.delete(key);
+    },
+  };
+};
+
+export const createMemorySecureStore = (): LynxSecureStore & { snapshot: () => Record<string, string> } => {
+  const map = new Map<string, string>();
+  return {
+    getToken: async (key) => map.get(key),
+    setToken: async (key, token) => {
+      map.set(key, token);
+      return true;
+    },
+    deleteToken: async (key) => {
+      map.delete(key);
+    },
+    snapshot: () => Object.fromEntries(map.entries()),
+  };
+};
+
+export const jsonResponse = (status: number, body: unknown): LynxHttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+export type RecordedRequest = {
+  url: string;
+  method: string;
+  headers?: Record<string, string>;
+  body?: string;
+};
+
+export const createMemoryClock = () => {
+  const sleeps: number[] = [];
+  const waiters: Array<{ ms: number; resolve: () => void }> = [];
+  return {
+    now: () => Date.now(),
+    sleeps,
+    sleep: async (ms: number, signal?: AbortSignal) => {
+      sleeps.push(ms);
+      if (signal?.aborted) return;
+      await new Promise<void>((resolve) => {
+        const finish = () => resolve();
+        waiters.push({ ms, resolve: finish });
+        signal?.addEventListener('abort', finish, { once: true });
+      });
+    },
+    flush: (ms?: number) => {
+      const pending = ms === undefined ? waiters.splice(0) : waiters.filter((waiter) => waiter.ms === ms);
+      if (ms !== undefined) {
+        for (let index = waiters.length - 1; index >= 0; index -= 1) {
+          if (waiters[index]?.ms === ms) waiters.splice(index, 1);
+        }
+      }
+      for (const waiter of pending) waiter.resolve();
+    },
+  };
+};
+
+export const createScriptedHttp = (
+  handler: (request: RecordedRequest) => LynxHttpResponse | Promise<LynxHttpResponse | null> | null,
+) => {
+  const requests: RecordedRequest[] = [];
+  const request = async (url: string, init?: LynxHttpInit): Promise<LynxHttpResponse> => {
+    const recorded: RecordedRequest = {
+      url,
+      method: init?.method ?? 'GET',
+      headers: init?.headers,
+      body: init?.body,
+    };
+    requests.push(recorded);
+    const response = await handler(recorded);
+    if (!response) {
+      return { ok: false, status: 0, json: async () => null };
+    }
+    return response;
+  };
+  return { request, requests };
+};
+
+export const createScriptedRelay = (
+  handler: (request: RecordedRequest, relay: LynxRelayConfig) => LynxHttpResponse | Promise<LynxHttpResponse | null> | null,
+) => {
+  const requests: RecordedRequest[] = [];
+  const openRelay = async (relay: LynxRelayConfig): Promise<LynxHttpTransport> => ({
+    fetch: async (path, init) => {
+      const recorded: RecordedRequest = {
+        url: path,
+        method: init?.method ?? 'GET',
+        headers: init?.headers,
+        body: init?.body,
+      };
+      requests.push(recorded);
+      return (await handler(recorded, relay)) ?? { ok: false, status: 0, json: async () => null };
+    },
+    close: () => undefined,
+  });
+  return { openRelay, requests };
+};
+
+export const createMemoryHost = (overrides: Partial<LynxHostAdapters> = {}): LynxHostAdapters => ({
+  request: async () => ({ ok: false, status: 0, json: async () => null }),
+  secureStore: createMemorySecureStore(),
+  metadataStore: createMemoryJsonStore(),
+  clock: {
+    now: () => Date.now(),
+    sleep: async () => undefined,
+  },
+  createId: () => 'conn_test',
+  ...overrides,
+});

--- a/packages/lynx/src/index.ts
+++ b/packages/lynx/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Lynx-track modules. The host app is not in tree yet — import the connect
+ * kernel from `@openchamber/lynx/connect` and bind host adapters.
+ */
+export * from './connect/index.ts';
+export type { LynxHostAdapters, LynxSecureStore, LynxJsonStore, LynxClock, LynxLogger } from './host/adapters.ts';
+export {
+  createMemoryHost,
+  createMemoryJsonStore,
+  createMemorySecureStore,
+  createMemoryClock,
+  createScriptedHttp,
+  createScriptedRelay,
+  jsonResponse,
+} from './host/memory.ts';

--- a/packages/lynx/tsconfig.json
+++ b/packages/lynx/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/packages/lynx/vitest.config.ts
+++ b/packages/lynx/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+import { bunTestShim, sharedExclude } from '../../vitest.shared.ts';
+
+export default defineConfig({
+  test: {
+    name: '@openchamber/lynx',
+    environment: 'node',
+    isolate: true,
+    exclude: sharedExclude,
+  },
+  resolve: {
+    alias: {
+      'bun:test': bunTestShim,
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'packages/vscode',
       'packages/electron',
       'packages/mobile',
+      'packages/lynx',
       'packages/relay-server',
       'deploy/update-service',
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Independent Lynx track. **Do not merge to `main`.** Targets `work/lynx-native`.

There is still no Lynx host app. This PR adds `@openchamber/lynx` so a future iOS/Android shell can import a connect kernel wired to the official Capacitor/web APIs.

## What landed

- `createLynxConnectionController(host)` — splash/auto-connect, instance list add/delete, password unlock
- Persist the **full** LAN + relay candidate set (`relayUrl` + `hostEncPubJwk`). Tokens only in the secure-store adapter
- Pairing v2 QR / paste / `openchamber://connect?v=2&p=…` redeem on `POST /api/client-auth/pairing/redeem` (no invented nearby redeem)
- Same `openchamber://` intent union as Cap `deepLinks.ts`; pairing can run on welcome; other intents stash until `setReady`
- Connect race: LAN first, relay after 1.5s; **relay-only skips the wait**
- Log sanitizer never forwards tokens / secrets / passwords / grants
- Gap board updated honestly (kernel landed; host splash / Keychain / camera labeled stubs; 真机过 not executed)

## Integration point

```ts
import { createLynxConnectionController } from '@openchamber/lynx/connect';

const controller = createLynxConnectionController({
  request,       // native HTTP to a LAN/tunnel URL
  openRelay,     // official E2EE tunnel, then the same HTTP paths
  secureStore,   // Keychain / Keystore
  metadataStore, // instance list without tokens
  bindRuntime,   // switch the shell origin + bearer
  scanQr,        // optional camera; kernel only parses
});

await controller.resolveLaunch(); // splash while auto-connect runs
```

Docs: `packages/lynx/README.md`, `packages/lynx/src/connect/DOCUMENTATION.md`.

## API mapping

| Action | Official route | Notes |
|---|---|---|
| Reachability | `GET /health` | No bearer. Optional `serverId` must match a paired relay identity |
| Session probe | `GET /auth/session` | Bearer when present. `401` / `authenticated:false` → password |
| Password unlock | `POST /auth/session` | `{ password, trustDevice, issueClientToken, clientKind: 'mobile', dedupeKey }` |
| Pairing redeem v2 | `POST /api/client-auth/pairing/redeem` | `{ pairingId, secret, clientKind: 'mobile', dedupeKey }`. One-shot |
| Refresh LAN set | `GET /api/client-auth/connection/candidates` | After bind. Echoed `serverId` required |

## How to test against a real server

1. Run OpenChamber (LAN). On the host: **Add a device** → pairing v2 QR / `openchamber://connect?v=2&p=…`
2. In a Node/Lynx host harness, inject `request` as native HTTP to that LAN URL
3. `controller.applyDeepLinkUrl(link)` or `redeemPairing(parsePairingConnectionPayload(link))`
4. Confirm metadata has both `direct` and `relay` candidates and the token is only in the secure store
5. Kill and `resolveLaunch()` — splash then auto-connect via `/health` + `/auth/session`
6. Password path: connect to a protected server without a token → `phase: 'password'` → `submitPassword`
7. Relay-away: bind `openRelay` to the official tunnel client; a dead LAN should fall through after 1.5s (or immediately if every LAN probe fails)

Unit stand-in (this PR):

```sh
bunx vitest run --project @openchamber/lynx
```

## Labeled stubs / blockers

| Item | Status |
|---|---|
| Lynx iOS/Android host package | Missing — kernel is the import path |
| Splash / welcome Lynx page | Missing — kernel exposes `phase` + `autoConnectLabel` |
| Keychain / Keystore plugin | Adapter landed; native binding is host work |
| QR camera | Parse + redeem landed; `scanQr` is host work |
| Official relay tunnel | `openRelay` adapter; do not invent a redeem URL |
| Lynx APK / iOS CI | Missing (unit project only) |
| 真机过 | **not executed** (Linux cloud agent; no Xcode/adb) |

## Checklist

- [x] No Bonjour / Nearby browse
- [x] No invented ASR / voice
- [x] No invented redeem API
- [x] Official health / session / pairing redeem routes
- [x] Tokens never logged
- [x] 代码接上 (kernel) + unit CI
- [ ] CI绿 for APK / iOS simulator (not claimed)
- [ ] 真机过 (not executed)

## Validation

- `bunx vitest run --project @openchamber/lynx` — 29 tests passed
- `bun run --cwd packages/lynx type-check`
- `bun run --cwd packages/lynx lint`
- `bun run dead-code` inspected (Lynx workspace clean of unused files/exports)

Not validated: physical device, Keychain, camera, live relay tunnel, Lynx page render.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c40bc4aa-e33b-4f4d-9a61-945d898b4a8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c40bc4aa-e33b-4f4d-9a61-945d898b4a8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

