### PR TITLE
feat(lynx): connect / pairing v2 / session-index client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,10 @@
         "electron-builder": "^26.0.0",
       },
     },
+    "packages/lynx": {
+      "name": "@openchamber/lynx",
+      "version": "1.19.7-beta.7",
+    },
     "packages/mobile": {
       "name": "@openchamber/mobile",
       "version": "1.19.6",
@@ -1025,6 +1029,8 @@
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
     "@openchamber/electron": ["@openchamber/electron@workspace:packages/electron"],
+
+    "@openchamber/lynx": ["@openchamber/lynx@workspace:packages/lynx"],
 
     "@openchamber/mobile": ["@openchamber/mobile@workspace:packages/mobile"],
 

--- a/docs/lynx-acceptance.md
+++ b/docs/lynx-acceptance.md
@@ -136,8 +136,8 @@ The author of a chat/list/navigation slice owns a harness that can run without a
 | **List prepend** | Load-older keeps the same turn under the finger (`maintainVisibleContentPosition`) | `TimelineList.tsx` contract tests |
 | **Streaming grow** | `maintainScrollAtEnd` while pinned; no follow when user scrolled away | LegendList flags, not a watchdog timer |
 | **IME occupancy** | Collapsed composer height published; queue/Changes do not jump on keyboard | Cap occupancy CSS variables — re-specify in Lynx units |
-| **Connect race** | LAN headstart then relay; relay-only skips the wait | `mobileConnections.ts` |
-| **Instance switch** | Query/runtime identity cleared; no token leak across servers | ui-api-decoupling |
+| **Connect race** | LAN headstart then relay; relay-only skips the wait | `packages/lynx/src/connection/probe.test.ts` (Lynx) / `mobileConnections.ts` (Cap) |
+| **Instance switch** | Query/runtime identity cleared; no token leak across servers | `packages/lynx/src/session-index/store.test.ts` + ui-api-decoupling |
 
 ### How to run them without a user
 

--- a/docs/lynx-gap-board.md
+++ b/docs/lynx-gap-board.md
@@ -22,7 +22,26 @@ Lynx app skeleton **does not exist**. This board is seeded honestly from `docs/l
 | Branch `work/lynx-native` from `b444b0316` | Docs gate only |
 | This documentation set | `docs/lynx-feature-inventory.md`, `docs/lynx-pitfalls.md`, `docs/lynx-gap-board.md`, `docs/lynx-acceptance.md`, `docs/lynx-ia-ui.md` |
 
-Nothing else is landed. There is no Lynx package, no host app, no CI workflow, no list, no connect screen.
+Nothing is **landed** under the 三关 rule (代码接上 + CI绿). The connect client below is 代码接上 only.
+
+---
+
+## 代码接上 (not landed — CI绿 + 真机过 missing)
+
+Client library: `packages/lynx` (`@openchamber/lynx`). No host LynxView, no pixel UI, no track CI.
+
+| Item | Cap/web source | Lynx note |
+|---|---|---|
+| Pairing v2 parse + paste/QR payload | `connectionPayload.ts`, `mobileQrScan.ts` | v1 rejected. Camera scan is host-owned. No Nearby / Bonjour. |
+| `openchamber://` parse + build | `deepLinks.ts` | Same intent union. Apply/navigation is still host. |
+| Connect / auto-connect / password / redeem | `mobileConnections.ts` | Real `GET /health`, `GET\|POST /auth/session`, `POST /api/client-auth/pairing/redeem`. Persists full LAN+relay candidate set. Token in injected secure store — never logged, never in metadata. |
+| Connect race harness | `mobileConnections.ts` | Unit: relay-only skips the 1.5s LAN headstart (`src/connection/probe.test.ts`). |
+| Session-index GET / pin / lookup | `session-index-api.ts` | `GET /api/openchamber/session-index`. Failure ≠ empty. Runtime-key cache. |
+| Projects home data path | `useMobileProjectsHomeModel.ts` | `projectSessionIndexHome` + `createSessionIndexHomeBindings`. No pixel polish. |
+
+**CI绿:** missing (no Lynx Android/iOS workflow yet). Local Vitest `@openchamber/lynx` is not track CI.
+
+**真机过:** not executed (environment: Linux cloud VM; no Xcode, no adb, no physical device).
 
 ---
 
@@ -35,11 +54,11 @@ Seeded from the inventory. Grouped so a slice can pick a coherent vertical.
 | Item | Cap/web source | Lynx note |
 |---|---|---|
 | Lynx app package (iOS + Android) | `packages/mobile` | New tree; do not wrap WKWebView |
-| Connect / splash while auto-connect resolves | `MobileApp.tsx` welcome | Real `GET /health` + session |
-| Instance list, add, delete, password unlock | `mobileConnections.ts` | Persist **full** LAN+relay candidate set |
-| QR + pairing-link redeem v2 | `mobileQrScan.ts` | No invented redeem API |
-| `openchamber://` parse + apply | `deepLinks.ts` | Same intent union |
-| Secure store (Keychain / Keystore) | Capacitor secure storage | Never log tokens |
+| Connect / splash while auto-connect resolves | `MobileApp.tsx` welcome | Client auto-connect exists in `packages/lynx`; **welcome UI + host splash** still missing |
+| Instance list, add, delete, password unlock | `mobileConnections.ts` | Client CRUD + password unlock exist; **Instances UI** still missing |
+| QR + pairing-link redeem v2 | `mobileQrScan.ts` | Link parse + redeem exist; **camera plugin** is host-owned |
+| `openchamber://` parse + apply | `deepLinks.ts` | Parse/build exist; **apply / navigation** still missing |
+| Secure store (Keychain / Keystore) | Capacitor secure storage | Injected adapter only — **native Keychain/Keystore wiring** still missing |
 | Four-tab dock | `mobileTabs.ts` | Chat is **pushed**, not a tab |
 | Host Tab/Nav embedding decision | README § tab bar | See `docs/lynx-ia-ui.md` — do not auto-skin twice |
 
@@ -54,7 +73,7 @@ Seeded from the inventory. Grouped so a slice can pick a coherent vertical.
 | New-session draft page | `kind: 'draft'` |
 | Add project directory explorer | `DirectoryExplorerDialog` |
 | Header 扫一扫 / 切换实例 | `MobileProjectsHome` |
-| Session index as data source | `GET /api/openchamber/session-index` (server) |
+| Session index as data source | `GET /api/openchamber/session-index` (server) | Client + home projection in `packages/lynx`; **Projects UI** still missing |
 
 ### Chat
 
@@ -132,10 +151,10 @@ Glass-container fusion (`spacing`, `glass-interactive`, `glass-tint-color`) is *
 
 First implementation slice after this doc gate (order is deliberate: connect → shell → list engine → one real transcript).
 
-1. **Host app skeleton** (iOS + Android) that can load a Lynx page. Decide embedding (`docs/lynx-ia-ui.md`) **before** drawing a dock.
-2. **Connect + instance persistence** against a real server (LAN candidate, then relay). No demo hosts.
+1. **Host app skeleton** (iOS + Android) that can load a Lynx page. Decide embedding (`docs/lynx-ia-ui.md`) **before** drawing a dock. Wire `packages/lynx` adapters (HTTP, Keychain/Keystore, optional relay tunnel).
+2. **Connect UI + instance persistence host** — client layer is 代码接上 in `packages/lynx`; still need welcome/instances surfaces, native secure store, and a real server 真机 pass (LAN candidate, then relay). No demo hosts. No Bonjour.
 3. **Four-tab shell** with chat as a pushed page. System Tab/Nav if host-owned; Lynx dock only if Lynx owns chrome.
-4. **Projects home** from session-index (failure ≠ empty).
+4. **Projects home UI** from the session-index bindings in `packages/lynx` (failure ≠ empty).
 5. **LegendList-semantics chat list** + send/stop on official APIs. This is the quality gate; do not prototype TanStack-style split lists “just to see pixels”.
 6. **Settings home + slug map** (all 21 rows visible; bodies may still be stubs **labeled stubs**, never fake-success).
 7. **CI** that builds Android debug APK + iOS simulator. Linux analyze alone is never “CI绿”.
@@ -192,7 +211,7 @@ A row moves here only after 代码接上 + CI绿 and a **written** device log (d
 
 | Slug | Status | First honest body |
 |---|---|---|
-| `instances` | missing | List + add + QR; persist v2 `relayUrl` |
+| `instances` | missing | Client list/add/delete exist in `packages/lynx`; Settings page + QR camera still missing. Persist v2 `relayUrl`. |
 | `appearance` | missing | Language + theme (`flexoki-*` ids). No `iosNativeUi` toggle |
 | `chat` | missing | Real GET/PUT `/api/config/settings` chat fields |
 | `notifications` | missing | Toggles + APNs/FCM register |

--- a/knip.json
+++ b/knip.json
@@ -65,6 +65,15 @@
         "scripts/**/*.{js,cjs,mjs}"
       ]
     },
+    "packages/lynx": {
+      "entry": [
+        "src/index.ts",
+        "src/**/*.test.ts"
+      ],
+      "project": [
+        "src/**/*.ts"
+      ]
+    },
     "packages/vscode": {
       "entry": [
         "src/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}",

--- a/packages/lynx/DOCUMENTATION.md
+++ b/packages/lynx/DOCUMENTATION.md
@@ -1,0 +1,64 @@
+# Lynx connect / session client
+
+Owning package for the Lynx rewrite’s **connection, pairing v2, deep links, and session-index** data path. Product behavior is copied from Capacitor + shared UI on `work/lynx-native` (`packages/ui/src/apps/mobileConnections.ts`, `mobileQrScan.ts`, `deepLinks.ts`, `packages/ui/src/lib/connectionPayload.ts`, `packages/ui/src/lib/session-index-api.ts`).
+
+## Runtime boundaries
+
+| Need | Route / owner | Lynx path |
+|---|---|---|
+| Pairing redeem | `POST /api/client-auth/pairing/redeem` | `redeemPairingConnection` — one shot on the first live transport |
+| Password + device token | `POST /auth/session` with `issueClientToken: true` | `submitPassword` |
+| Reachability | `GET /health` (no bearer until serverId matches) | `probeConnectionCandidates` |
+| Session auth | `GET /auth/session` | same probe / `validateMobileConnectionSession` |
+| LAN refresh | `GET /api/client-auth/connection/candidates` | `refreshActiveConnectionCandidates` |
+| Session list | `GET /api/openchamber/session-index` | `loadSessionIndexSnapshot` |
+| Session by id | `GET /api/openchamber/session-index/session/:id` | `lookupSessionIndexById` |
+| Pin / unpin | `POST` / `DELETE` `…/session/:id/pin` | `pinSession` / `unpinSession` |
+| Official OpenCode session CRUD | `@opencode-ai/sdk/v2` | **not this package** — chat track |
+
+Do not invent `/api/nearby/redeem` or Bonjour browse.
+
+## Connect race
+
+Copied from Cap:
+
+- Direct (LAN/tunnel) candidates keep priority.
+- When a relay candidate exists **and** at least one direct candidate exists, the relay probe starts after `RELAY_RACE_HEADSTART_MS` (1500).
+- Relay-only payloads **must not** sleep that headstart.
+- If every direct candidate is unreachable, start relay immediately (cancel remaining headstart).
+- Auth rejection (401 / `authenticated: false`) applies to every transport (same token) and short-circuits to `needs-login`.
+- When the saved set includes a relay `serverId`, a direct `/health` that reports a **different** `serverId` is skipped (do not send the bearer there).
+
+Harness: `src/connection/probe.test.ts` (`relay-only does not sleep 1.5s`).
+
+## Persistence
+
+- Metadata key: `openchamber.mobile.connections.v1` (same as Cap so a later host can migrate).
+- Token key: `openchamber.mobile.token.<urlencoded runtime key>` in the injected secure store.
+- Runtime key: `relay:<serverId>@<relayUrl>` when a relay candidate exists, else the normalized direct URL.
+- Metadata never stores the bearer on the native path. Token writes are awaited before a runtime switch.
+- Limit 12 saved instances. Dedupe by shared relay identity or shared normalized direct URL — never by hostname alone.
+
+## Session index
+
+- Authoritative GET. `available !== true` or HTTP failure is **not** an empty success.
+- 501 → `unsupported` (external OpenCode without the index).
+- Cache is keyed by **runtime key** (LAN↔relay share the same device identity).
+- Failed refresh keeps the previous snapshot and surfaces `failed`.
+- Instance switch (`clearRuntime`) drops in-memory index state.
+
+Projects home consumes `projectSessionIndexHome(snapshot)` — cards + pinned / in-progress rows from the index. Live busy overlays and worktree git probes stay with later UI/sync slices.
+
+## Deep links
+
+`parseDeepLink` / `buildDeepLink` match `packages/ui/src/apps/deepLinks.ts`. Connect requires a valid v2 payload. v1 `?v=1&token=` is `null`.
+
+QR / paste: `parseConnectionPayload` accepts v2 pairing links or a bare `http(s)` URL. Camera scanning is a host plugin, not this package.
+
+## Remaining for 三关
+
+| Gate | This slice |
+|---|---|
+| 代码接上 | Client calls the real routes above. Host must still inject HTTP + Keychain + (later) relay tunnel. |
+| CI绿 | Missing — track CI (Android debug APK + iOS sim) is a later slice. Unit tests here are local only. |
+| 真机过 | Not executed (Linux cloud VM; no Xcode / physical device). |

--- a/packages/lynx/README.md
+++ b/packages/lynx/README.md
@@ -1,0 +1,37 @@
+# @openchamber/lynx
+
+Lynx-side **connect / pairing / session-index** client for the `work/lynx-native` rewrite.
+
+This package is a TypeScript client layer, not a pixel UI and not a host app. It maps to the same OpenChamber / OpenCode routes Capacitor mobile uses (`packages/ui` + `packages/mobile`).
+
+## What this owns
+
+- Pairing v2 parse (`openchamber://connect?v=2&p=…`). Legacy v1 links are rejected.
+- `openchamber://` intent parse/build (same union as `packages/ui/src/apps/deepLinks.ts`).
+- Saved-instance persistence: ordered LAN + relay **candidates**, token in an injected secure store.
+- Connect / auto-connect / password unlock / pairing redeem on a **reachable** candidate (`GET /health`, `GET|POST /auth/session`, `POST /api/client-auth/pairing/redeem`).
+- Session-index GET / pin / lookup keyed by runtime identity, with failure ≠ empty.
+- Projects-home projection (API/types, not UI polish).
+
+## What this does not own
+
+- Host LynxView / four-tab dock / pixel chrome (`docs/lynx-ia-ui.md`).
+- Nearby / Bonjour browse (does not exist in Cap; pairing v2 excluded it).
+- Native ASR / voice product.
+- FCM / APNs registration (leave to the push track; keep `com.yee94.openchamber[.debug]`).
+- E2EE relay tunnel implementation — inject `openRelayTunnel` when the host has one.
+- Chat LegendList, Settings editors, CI.
+
+## Adapters the host must inject
+
+| Adapter | Cap counterpart |
+|---|---|
+| `http.request` | CapacitorHttp then fetch |
+| `secureStore` | Keychain / Keystore (`@aparajita/capacitor-secure-storage`) |
+| `metadataStore` | localStorage `openchamber.mobile.connections.v1` |
+| `openRelayTunnel` | `createRelayTunnelClient` (optional until relay lands) |
+| `getDevicePlatform` | Capacitor `ios` / `android` |
+
+Do not log tokens, pairing secrets, or bearer headers.
+
+See `DOCUMENTATION.md`.

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openchamber/lynx",
+  "version": "1.19.7-beta.7",
+  "private": true,
+  "type": "module",
+  "description": "Lynx mobile client layer: connect, pairing v2, and session-index data path",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint \"./src/**/*.ts\" --config ../../eslint.config.js"
+  }
+}

--- a/packages/lynx/src/connection/candidates.ts
+++ b/packages/lynx/src/connection/candidates.ts
@@ -1,0 +1,111 @@
+import type { PairingEndpointCandidate } from '../pairing/payload';
+import type { LynxConnectInput, LynxRelayConfig, LynxTransportCandidate } from './types';
+import { getConnectionStorageKey, normalizeConnectionUrl } from './urls';
+
+export const parseRelayConfig = (value: unknown): LynxRelayConfig | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.relayUrl !== 'string' || !record.relayUrl.trim()) return null;
+  if (typeof record.serverId !== 'string' || !record.serverId.trim()) return null;
+  const jwk = record.hostEncPubJwk;
+  if (!jwk || typeof jwk !== 'object' || Array.isArray(jwk)) return null;
+  const key = jwk as Record<string, unknown>;
+  if (key.kty !== 'EC' || key.crv !== 'P-256') return null;
+  if (typeof key.x !== 'string' || !key.x || typeof key.y !== 'string' || !key.y) return null;
+  return {
+    relayUrl: record.relayUrl,
+    serverId: record.serverId,
+    hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: key.x, y: key.y },
+  };
+};
+
+export const parseCandidate = (value: unknown): LynxTransportCandidate | null => {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (record.kind === 'direct') {
+    return typeof record.url === 'string' && record.url.trim() ? { kind: 'direct', url: record.url } : null;
+  }
+  if (record.kind === 'relay') {
+    const relay = parseRelayConfig(record.relay);
+    return relay ? { kind: 'relay', relay } : null;
+  }
+  return null;
+};
+
+export const serializeCandidate = (candidate: LynxTransportCandidate): unknown =>
+  candidate.kind === 'relay'
+    ? {
+      kind: 'relay',
+      relay: {
+        relayUrl: candidate.relay.relayUrl,
+        serverId: candidate.relay.serverId,
+        hostEncPubJwk: candidate.relay.hostEncPubJwk,
+      },
+    }
+    : { kind: 'direct', url: candidate.url };
+
+export const migrateLegacyCandidates = (record: Record<string, unknown>): LynxTransportCandidate[] => {
+  if (record.mode === 'relay') {
+    const relay = parseRelayConfig(record.relay);
+    return relay ? [{ kind: 'relay', relay }] : [];
+  }
+  return typeof record.url === 'string' ? directCandidatesFromUrl(record.url) : [];
+};
+
+export const directCandidatesFromUrl = (url: string): LynxTransportCandidate[] => {
+  const normalized = (() => {
+    try {
+      return normalizeConnectionUrl(url);
+    } catch {
+      return '';
+    }
+  })();
+  return normalized ? [{ kind: 'direct', url: normalized }] : [];
+};
+
+export const buildCandidatesFromInput = (input: LynxConnectInput): LynxTransportCandidate[] => {
+  if (input.candidates && input.candidates.length > 0) return input.candidates;
+  const list: LynxTransportCandidate[] = [];
+  if (typeof input.url === 'string' && input.url.trim() && !/^relay:\/\//i.test(input.url.trim())) {
+    list.push(...directCandidatesFromUrl(input.url));
+  }
+  if (input.relay) list.push({ kind: 'relay', relay: input.relay });
+  return list;
+};
+
+export const candidateSetsMatch = (left: LynxTransportCandidate[], right: LynxTransportCandidate[]): boolean => {
+  const leftRelay = left.find((candidate) => candidate.kind === 'relay');
+  const leftServerId = leftRelay && leftRelay.kind === 'relay' ? leftRelay.relay.serverId : null;
+  const leftRelayUrl = leftRelay && leftRelay.kind === 'relay' ? leftRelay.relay.relayUrl.trim() : null;
+  const leftUrls = new Set(
+    left.filter((candidate) => candidate.kind === 'direct').map((candidate) => getConnectionStorageKey(candidate.url)),
+  );
+  return right.some((candidate) => {
+    if (candidate.kind === 'relay') {
+      return leftServerId !== null && candidate.relay.serverId === leftServerId && candidate.relay.relayUrl.trim() === leftRelayUrl;
+    }
+    return leftUrls.has(getConnectionStorageKey(candidate.url));
+  });
+};
+
+export const pairingCandidatesToMobile = (candidates: PairingEndpointCandidate[]): LynxTransportCandidate[] =>
+  [...candidates]
+    .sort((left, right) => {
+      const delta = (left.priority ?? 100) - (right.priority ?? 100);
+      if (delta !== 0) return delta;
+      const rank = (candidate: PairingEndpointCandidate): number => (
+        candidate.type === 'relay' ? 2 : candidate.url.startsWith('https://') ? 0 : 1
+      );
+      return rank(left) - rank(right);
+    })
+    .flatMap((candidate): LynxTransportCandidate[] => {
+      if (candidate.type === 'relay') {
+        const relay = parseRelayConfig({
+          relayUrl: candidate.relayUrl,
+          serverId: candidate.serverId,
+          hostEncPubJwk: candidate.hostEncPubJwk,
+        });
+        return relay ? [{ kind: 'relay', relay }] : [];
+      }
+      return directCandidatesFromUrl(candidate.url);
+    });

--- a/packages/lynx/src/connection/client.test.ts
+++ b/packages/lynx/src/connection/client.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildPairingConnectionPayload } from '../pairing/payload';
+import { createLynxConnectionClient } from './client';
+import { createMemoryKvStore, createMemorySecureStore } from './persist';
+import type { LynxHttpResponse, LynxRelayConfig } from './types';
+
+const relay: LynxRelayConfig = {
+  relayUrl: 'wss://relay.example/ws',
+  serverId: 'srv_home',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' },
+};
+
+const jsonResponse = (status: number, body: unknown): LynxHttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+describe('LynxConnectionClient', () => {
+  test('redeems pairing v2 on the first reachable candidate and persists LAN+relay', async () => {
+    const requests: Array<{ url: string; body?: string }> = [];
+    const client = createLynxConnectionClient({
+      metadataStore: createMemoryKvStore(),
+      secureStore: createMemorySecureStore(),
+      getDevicePlatform: () => 'ios',
+      http: {
+        request: async (url, init) => {
+          requests.push({ url, body: init?.body });
+          if (url.endsWith('/health')) return jsonResponse(200, { serverId: 'srv_home' });
+          if (url.endsWith('/api/client-auth/pairing/redeem')) {
+            return jsonResponse(200, {
+              ok: true,
+              clientToken: 'issued-token',
+              server: { label: 'Studio' },
+            });
+          }
+          return jsonResponse(404, {});
+        },
+      },
+    });
+
+    const payload = buildPairingConnectionPayload({
+      pairingId: 'pair_1',
+      secret: 'one-time-secret',
+      label: 'Studio',
+      candidates: [
+        { type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 },
+        { type: 'relay', relayUrl: relay.relayUrl, serverId: relay.serverId, hostEncPubJwk: relay.hostEncPubJwk, priority: 30 },
+      ],
+    });
+
+    const result = await client.redeemPairingConnection(payload);
+    expect(result.status).toBe('connected');
+    if (result.status !== 'connected') return;
+    expect(result.connection.candidates.map((candidate) => candidate.kind)).toEqual(['direct', 'relay']);
+    expect(result.connection.hasToken).toBe(true);
+    expect(result.runtimeKey.startsWith('relay:')).toBe(true);
+    expect(requests.some((request) => request.url.endsWith('/api/client-auth/pairing/redeem'))).toBe(true);
+    const redeem = requests.find((request) => request.url.endsWith('/api/client-auth/pairing/redeem'));
+    const body = JSON.parse(redeem?.body ?? '{}') as Record<string, unknown>;
+    expect(body.pairingId).toBe('pair_1');
+    expect(body.secret).toBe('one-time-secret');
+    expect(body.clientKind).toBe('mobile');
+    expect(body.dedupeKey).toMatch(/^mobile:/);
+    expect(client.identity.get()?.clientToken).toBe('issued-token');
+    expect(JSON.stringify(client.loadConnections()[0])).not.toContain('issued-token');
+  });
+
+  test('does not invent a nearby redeem route when LAN is down and no relay tunnel is injected', async () => {
+    const urls: string[] = [];
+    const client = createLynxConnectionClient({
+      metadataStore: createMemoryKvStore(),
+      secureStore: createMemorySecureStore(),
+      http: {
+        request: async (url) => {
+          urls.push(url);
+          return jsonResponse(503, {});
+        },
+      },
+    });
+    const result = await client.redeemPairingConnection(buildPairingConnectionPayload({
+      pairingId: 'pair_1',
+      secret: 's',
+      candidates: [
+        { type: 'lan', url: 'http://192.168.1.20:4096' },
+        { type: 'relay', relayUrl: relay.relayUrl, serverId: relay.serverId, hostEncPubJwk: relay.hostEncPubJwk },
+      ],
+    }));
+    expect(result).toEqual({ status: 'failed', error: 'unreachable' });
+    expect(urls.some((url) => url.includes('/nearby/'))).toBe(false);
+    expect(urls.some((url) => url.endsWith('/api/client-auth/pairing/redeem'))).toBe(false);
+  });
+
+  test('password unlock issues a client token over POST /auth/session', async () => {
+    const client = createLynxConnectionClient({
+      metadataStore: createMemoryKvStore(),
+      secureStore: createMemorySecureStore(),
+      http: {
+        request: async (url, init) => {
+          if (url.endsWith('/health')) return jsonResponse(200, {});
+          if (url.endsWith('/auth/session') && init?.method === 'POST') {
+            const body = JSON.parse(init.body ?? '{}') as Record<string, unknown>;
+            expect(body.issueClientToken).toBe(true);
+            expect(body.trustDevice).toBe(true);
+            return jsonResponse(200, { clientToken: 'pw-token' });
+          }
+          return jsonResponse(404, {});
+        },
+      },
+    });
+    const result = await client.submitPassword({
+      id: 'pending-1',
+      label: 'Home',
+      candidates: [{ kind: 'direct', url: 'http://192.168.1.20:4096' }],
+    }, 'secret-password');
+    expect(result.status).toBe('connected');
+    if (result.status !== 'connected') return;
+    expect(result.connection.hasToken).toBe(true);
+  });
+
+  test('auto-connect requires a saved token and switches the runtime on probe success', async () => {
+    const metadataStore = createMemoryKvStore();
+    const secureStore = createMemorySecureStore();
+    const client = createLynxConnectionClient({
+      metadataStore,
+      secureStore,
+      http: {
+        request: async (url) => {
+          if (url.endsWith('/health')) return jsonResponse(200, {});
+          if (url.endsWith('/auth/session')) return jsonResponse(200, { authenticated: true, scope: 'client' });
+          return jsonResponse(404, {});
+        },
+      },
+    });
+    expect(await client.autoConnectLastInstance()).toBe(false);
+    await client.upsert({
+      label: 'Home',
+      candidates: [{ kind: 'direct', url: 'http://192.168.1.20:4096' }],
+      clientToken: 'saved-token',
+    });
+    expect(await client.autoConnectLastInstance()).toBe(true);
+    expect(client.identity.get()?.transport).toEqual({ kind: 'direct', url: 'http://192.168.1.20:4096' });
+  });
+
+  test('deleting the active instance clears runtime identity', async () => {
+    const client = createLynxConnectionClient({
+      metadataStore: createMemoryKvStore(),
+      secureStore: createMemorySecureStore(),
+      http: {
+        request: async (url) => {
+          if (url.endsWith('/health')) return jsonResponse(200, {});
+          if (url.endsWith('/auth/session')) return jsonResponse(200, { authenticated: true, scope: 'client' });
+          return jsonResponse(404, {});
+        },
+      },
+    });
+    await client.upsert({
+      id: 'home',
+      label: 'Home',
+      candidates: [{ kind: 'direct', url: 'http://192.168.1.20:4096' }],
+      clientToken: 'tok',
+    });
+    await client.connect({ id: 'home' });
+    expect(client.identity.get()).not.toBeNull();
+    await client.remove('home');
+    expect(client.identity.get()).toBeNull();
+    expect(client.loadConnections()).toEqual([]);
+  });
+});

--- a/packages/lynx/src/connection/client.ts
+++ b/packages/lynx/src/connection/client.ts
@@ -1,0 +1,335 @@
+import type { PairingConnectionPayload } from '../pairing/payload';
+import { createUuid } from '../uuid';
+import { createRuntimeFetch, type LynxRuntimeFetch } from '../runtime/fetch';
+import { createRuntimeIdentityStore, type LynxRuntimeIdentityStore } from '../runtime/identity';
+import { buildCandidatesFromInput, candidateSetsMatch, pairingCandidatesToMobile } from './candidates';
+import {
+  RELAY_CONNECT_TIMEOUT_MS,
+  createFetchHttpClient,
+  createSystemClock,
+  raceWithTimeout,
+  requestWithTimeout,
+} from './http';
+import {
+  deleteSecureToken,
+  mobileClientDedupeKey,
+  readConnections,
+  readSecureToken,
+  upsertConnectionInList,
+  writeConnections,
+  writeSecureToken,
+} from './persist';
+import { establishLiveTransport, probeConnectionCandidates, validateMobileConnectionSession } from './probe';
+import type {
+  LynxClock,
+  LynxConnectInput,
+  LynxConnectResult,
+  LynxDevicePlatform,
+  LynxHttpClient,
+  LynxKvStore,
+  LynxPendingConnection,
+  LynxRelayTunnelFactory,
+  LynxSavedConnection,
+  LynxSecureStore,
+  LynxTransportCandidate,
+} from './types';
+import {
+  connectionDisplayUrl,
+  getConnectionLabel,
+  relayCandidateOf,
+  secureTokenKeyOf,
+} from './urls';
+
+const CLIENT_LABEL = 'OpenChamber Mobile';
+
+export type LynxConnectionClientDeps = {
+  http?: LynxHttpClient;
+  clock?: LynxClock;
+  metadataStore: LynxKvStore;
+  secureStore: LynxSecureStore;
+  openRelayTunnel?: LynxRelayTunnelFactory;
+  getDevicePlatform?: () => LynxDevicePlatform | undefined;
+  identity?: LynxRuntimeIdentityStore;
+};
+
+export type LynxConnectionClient = {
+  identity: LynxRuntimeIdentityStore;
+  runtimeFetch: LynxRuntimeFetch;
+  loadConnections: () => LynxSavedConnection[];
+  upsert: (draft: {
+    id?: string;
+    label: string;
+    candidates: LynxTransportCandidate[];
+    clientToken?: string;
+  }) => Promise<LynxSavedConnection[]>;
+  remove: (id: string) => Promise<LynxSavedConnection[]>;
+  connect: (input: LynxConnectInput) => Promise<LynxConnectResult>;
+  redeemPairingConnection: (payload: PairingConnectionPayload) => Promise<LynxConnectResult>;
+  submitPassword: (pending: LynxPendingConnection, password: string) => Promise<LynxConnectResult>;
+  autoConnectLastInstance: () => Promise<boolean>;
+  validateSession: (input: { url: string; clientToken?: string | null }) => Promise<boolean>;
+};
+
+const persistDraft = async (
+  deps: Required<Pick<LynxConnectionClientDeps, 'metadataStore' | 'secureStore'>> & { clock: LynxClock },
+  draft: {
+    id?: string;
+    label: string;
+    candidates: LynxTransportCandidate[];
+    clientToken?: string;
+  },
+): Promise<LynxSavedConnection[]> => {
+  if (draft.clientToken) {
+    const stored = await writeSecureToken(deps.secureStore, { candidates: draft.candidates }, draft.clientToken);
+    if (!stored) throw new Error('secure-store-failed');
+  }
+  const next = upsertConnectionInList(readConnections(deps.metadataStore), {
+    id: draft.id,
+    label: draft.label,
+    candidates: draft.candidates,
+    hasToken: Boolean(draft.clientToken) || undefined,
+    now: deps.clock.now(),
+  });
+  writeConnections(deps.metadataStore, next);
+  return next;
+};
+
+const resolveToken = async (
+  deps: Required<Pick<LynxConnectionClientDeps, 'secureStore' | 'metadataStore'>>,
+  input: LynxConnectInput,
+  saved: LynxSavedConnection | undefined,
+): Promise<string | undefined> => {
+  const explicit = input.clientToken?.trim() || undefined;
+  if (explicit) return explicit;
+  if (!saved?.hasToken) return undefined;
+  return readSecureToken(deps.secureStore, saved);
+};
+
+const redeemBody = (
+  payload: PairingConnectionPayload,
+  metadataStore: LynxKvStore,
+  platform: LynxDevicePlatform | undefined,
+): string => JSON.stringify({
+  pairingId: payload.pairingId,
+  secret: payload.secret,
+  clientLabel: CLIENT_LABEL,
+  clientKind: 'mobile',
+  deviceName: CLIENT_LABEL,
+  devicePlatform: platform,
+  dedupeKey: mobileClientDedupeKey(metadataStore),
+});
+
+const passwordBody = (
+  password: string,
+  metadataStore: LynxKvStore,
+  platform: LynxDevicePlatform | undefined,
+): string => JSON.stringify({
+  password,
+  trustDevice: true,
+  issueClientToken: true,
+  clientLabel: CLIENT_LABEL,
+  clientKind: 'mobile',
+  devicePlatform: platform,
+  dedupeKey: mobileClientDedupeKey(metadataStore),
+});
+
+export const createLynxConnectionClient = (input: LynxConnectionClientDeps): LynxConnectionClient => {
+  const http = input.http ?? createFetchHttpClient();
+  const clock = input.clock ?? createSystemClock();
+  const identity = input.identity ?? createRuntimeIdentityStore();
+  const nativeClient = true;
+  const probeDeps = {
+    http,
+    clock,
+    openRelayTunnel: input.openRelayTunnel,
+    nativeClient,
+  };
+  const runtimeFetch = createRuntimeFetch({ http, identity });
+
+  const loadConnections = (): LynxSavedConnection[] => readConnections(input.metadataStore);
+
+  const upsert: LynxConnectionClient['upsert'] = async (draft) => persistDraft(
+    { metadataStore: input.metadataStore, secureStore: input.secureStore, clock },
+    draft,
+  );
+
+  const remove: LynxConnectionClient['remove'] = async (id) => {
+    const connections = loadConnections();
+    const removed = connections.find((connection) => connection.id === id);
+    const next = connections.filter((connection) => connection.id !== id);
+    writeConnections(input.metadataStore, next);
+    if (removed) await deleteSecureToken(input.secureStore, removed);
+    const active = identity.get();
+    if (removed && active && secureTokenKeyOf(removed) === active.runtimeKey) {
+      identity.clear();
+    }
+    return next;
+  };
+
+  const connect: LynxConnectionClient['connect'] = async (connectInput) => {
+    try {
+      const saved = connectInput.id
+        ? loadConnections().find((connection) => connection.id === connectInput.id)
+        : undefined;
+      const candidates = buildCandidatesFromInput(connectInput);
+      const resolvedCandidates = candidates.length > 0 ? candidates : (saved?.candidates ?? []);
+      if (resolvedCandidates.length === 0) return { status: 'failed', error: 'url-required' };
+      const matched = saved ?? loadConnections().find((connection) => (
+        candidateSetsMatch(connection.candidates, resolvedCandidates)
+      ));
+      const label = connectInput.label?.trim()
+        || matched?.label
+        || getConnectionLabel(connectionDisplayUrl({ candidates: resolvedCandidates }));
+      const token = await resolveToken(
+        { secureStore: input.secureStore, metadataStore: input.metadataStore },
+        connectInput,
+        matched,
+      );
+      const result = await probeConnectionCandidates(resolvedCandidates, token, probeDeps);
+      if (result.status === 'unreachable') return { status: 'failed', error: 'unreachable' };
+      if (result.status === 'needs-login') {
+        await persistDraft(
+          { metadataStore: input.metadataStore, secureStore: input.secureStore, clock },
+          { id: matched?.id, label, candidates: resolvedCandidates },
+        );
+        return {
+          status: 'needs-login',
+          pending: {
+            id: matched?.id ?? createUuid(),
+            label,
+            candidates: resolvedCandidates,
+            relay: relayCandidateOf({ candidates: resolvedCandidates }) ?? undefined,
+            relayGrant: connectInput.relayGrant,
+          },
+        };
+      }
+      const runtimeKey = secureTokenKeyOf({ candidates: resolvedCandidates });
+      if (connectInput.clientToken?.trim()) {
+        const stored = await writeSecureToken(input.secureStore, { candidates: resolvedCandidates }, connectInput.clientToken.trim());
+        if (!stored) return { status: 'failed', error: 'secure-store-failed' };
+      }
+      const connections = await persistDraft(
+        { metadataStore: input.metadataStore, secureStore: input.secureStore, clock },
+        { id: matched?.id, label, candidates: resolvedCandidates, clientToken: token },
+      );
+      const connection = connections[0]!;
+      identity.switchToTransport(result.transport, token ?? null, runtimeKey);
+      return { status: 'connected', connection, transport: result.transport, runtimeKey };
+    } catch {
+      return { status: 'failed', error: 'invalid-url' };
+    }
+  };
+
+  const redeemPairingConnection: LynxConnectionClient['redeemPairingConnection'] = async (payload) => {
+    const deviceCandidates = pairingCandidatesToMobile(payload.candidates);
+    const chosen = await establishLiveTransport(deviceCandidates, probeDeps);
+    if (!chosen) return { status: 'failed', error: 'unreachable' };
+    const body = redeemBody(payload, input.metadataStore, input.getDevicePlatform?.());
+    const redeemInit = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body,
+    };
+    try {
+      const response = chosen.kind === 'relay'
+        ? await raceWithTimeout(
+          RELAY_CONNECT_TIMEOUT_MS,
+          chosen.tunnel.fetch('/api/client-auth/pairing/redeem', redeemInit),
+        )
+        : await requestWithTimeout(
+          http,
+          `${chosen.url}/api/client-auth/pairing/redeem`,
+          redeemInit,
+        );
+      if (!response?.ok) return { status: 'failed', error: 'auth-required' };
+      const result = await response.json().catch(() => null) as { clientToken?: unknown; server?: { label?: unknown } } | null;
+      const issuedToken = typeof result?.clientToken === 'string' ? result.clientToken.trim() : '';
+      if (!issuedToken) return { status: 'failed', error: 'auth-required' };
+      const serverLabel = typeof result?.server?.label === 'string' ? result.server.label : '';
+      const label = payload.label || serverLabel || getConnectionLabel(connectionDisplayUrl({ candidates: deviceCandidates }));
+      const runtimeKey = secureTokenKeyOf({ candidates: deviceCandidates });
+      const stored = await writeSecureToken(input.secureStore, { candidates: deviceCandidates }, issuedToken);
+      if (!stored) return { status: 'failed', error: 'secure-store-failed' };
+      const connections = await persistDraft(
+        { metadataStore: input.metadataStore, secureStore: input.secureStore, clock },
+        { label, candidates: deviceCandidates, clientToken: issuedToken },
+      );
+      const transport = chosen.kind === 'relay'
+        ? { kind: 'relay' as const, relay: chosen.relay }
+        : { kind: 'direct' as const, url: chosen.url };
+      identity.switchToTransport(transport, issuedToken, runtimeKey);
+      if (chosen.kind === 'relay') chosen.tunnel.close();
+      return { status: 'connected', connection: connections[0]!, transport, runtimeKey };
+    } catch {
+      if (chosen.kind === 'relay') chosen.tunnel.close();
+      return { status: 'failed', error: 'auth-required' };
+    }
+  };
+
+  const submitPassword: LynxConnectionClient['submitPassword'] = async (pending, password) => {
+    if (!password.trim()) return { status: 'failed', error: 'password-failed' };
+    const chosen = await establishLiveTransport(pending.candidates, probeDeps);
+    if (!chosen) return { status: 'failed', error: 'unreachable' };
+    const loginInit = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: passwordBody(password, input.metadataStore, input.getDevicePlatform?.()),
+    };
+    try {
+      const response = chosen.kind === 'relay'
+        ? await raceWithTimeout(RELAY_CONNECT_TIMEOUT_MS, chosen.tunnel.fetch('/auth/session', loginInit))
+        : await requestWithTimeout(http, `${chosen.url}/auth/session`, loginInit);
+      if (!response?.ok) return { status: 'failed', error: 'password-failed' };
+      const body = await response.json().catch(() => null) as { clientToken?: unknown } | null;
+      const issuedToken = typeof body?.clientToken === 'string' ? body.clientToken.trim() : '';
+      if (!issuedToken) return { status: 'failed', error: 'auth-required' };
+      const stored = await writeSecureToken(input.secureStore, { candidates: pending.candidates }, issuedToken);
+      if (!stored) return { status: 'failed', error: 'secure-store-failed' };
+      const connections = await persistDraft(
+        { metadataStore: input.metadataStore, secureStore: input.secureStore, clock },
+        { id: pending.id, label: pending.label, candidates: pending.candidates, clientToken: issuedToken },
+      );
+      const transport = chosen.kind === 'relay'
+        ? { kind: 'relay' as const, relay: chosen.relay }
+        : { kind: 'direct' as const, url: chosen.url };
+      const runtimeKey = secureTokenKeyOf({ candidates: pending.candidates });
+      identity.switchToTransport(transport, issuedToken, runtimeKey);
+      if (chosen.kind === 'relay') chosen.tunnel.close();
+      return { status: 'connected', connection: connections[0]!, transport, runtimeKey };
+    } catch {
+      if (chosen.kind === 'relay') chosen.tunnel.close();
+      return { status: 'failed', error: 'password-failed' };
+    }
+  };
+
+  const autoConnectLastInstance = async (): Promise<boolean> => {
+    const candidate = loadConnections()[0];
+    if (!candidate?.hasToken) return false;
+    const token = await readSecureToken(input.secureStore, candidate);
+    if (!token) return false;
+    const result = await probeConnectionCandidates(candidate.candidates, token, probeDeps);
+    if (result.status !== 'ok') return false;
+    await persistDraft(
+      { metadataStore: input.metadataStore, secureStore: input.secureStore, clock },
+      { id: candidate.id, label: candidate.label, candidates: candidate.candidates },
+    );
+    identity.switchToTransport(result.transport, token, secureTokenKeyOf(candidate));
+    return true;
+  };
+
+  const validateSession: LynxConnectionClient['validateSession'] = (sessionInput) =>
+    validateMobileConnectionSession(sessionInput, probeDeps);
+
+  return {
+    identity,
+    runtimeFetch,
+    loadConnections,
+    upsert,
+    remove,
+    connect,
+    redeemPairingConnection,
+    submitPassword,
+    autoConnectLastInstance,
+    validateSession,
+  };
+};

--- a/packages/lynx/src/connection/http.ts
+++ b/packages/lynx/src/connection/http.ts
@@ -1,0 +1,74 @@
+import type { LynxClock, LynxHttpClient, LynxHttpResponse, LynxRequestInit, LynxSessionStatus } from './types';
+
+export const CONNECT_TIMEOUT_MS = 8000;
+export const FAST_PROBE_TIMEOUT_MS = 2500;
+export const RELAY_CONNECT_TIMEOUT_MS = 15_000;
+export const RELAY_RACE_HEADSTART_MS = 1_500;
+
+export const createFetchHttpClient = (): LynxHttpClient => ({
+  request: async (url, init) => {
+    try {
+      const response = await fetch(url, {
+        method: init?.method || 'GET',
+        headers: init?.headers,
+        body: init?.body,
+        signal: init?.signal,
+      });
+      return {
+        ok: response.ok,
+        status: response.status,
+        json: () => response.json() as Promise<unknown>,
+      };
+    } catch {
+      return null;
+    }
+  },
+});
+
+export const createSystemClock = (): LynxClock => ({
+  now: () => Date.now(),
+  sleep: (ms) => new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  }),
+});
+
+export const raceWithTimeout = async <T,>(
+  timeoutMs: number,
+  operation: Promise<T | null>,
+): Promise<T | null> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timeoutId = setTimeout(() => resolve(null), timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } catch {
+    return null;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+};
+
+export const requestWithTimeout = async (
+  http: LynxHttpClient,
+  url: string,
+  init?: LynxRequestInit,
+  options?: { totalTimeoutMs?: number },
+): Promise<LynxHttpResponse | null> => {
+  const total = options?.totalTimeoutMs ?? CONNECT_TIMEOUT_MS;
+  return raceWithTimeout(total, http.request(url, init));
+};
+
+export const readSessionStatus = async (
+  response: { json: () => Promise<unknown> } | null,
+): Promise<LynxSessionStatus | null> => {
+  if (!response) return null;
+  const payload = await response.json().catch(() => null);
+  if (!payload || typeof payload !== 'object') return null;
+  const record = payload as Record<string, unknown>;
+  return {
+    authenticated: typeof record.authenticated === 'boolean' ? record.authenticated : undefined,
+    disabled: typeof record.disabled === 'boolean' ? record.disabled : undefined,
+    scope: typeof record.scope === 'string' ? record.scope : undefined,
+  };
+};

--- a/packages/lynx/src/connection/persist.test.ts
+++ b/packages/lynx/src/connection/persist.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  CONNECTIONS_STORAGE_KEY,
+  createMemoryKvStore,
+  createMemorySecureStore,
+  prefixedTokenKey,
+  readConnections,
+  readSecureToken,
+  upsertConnectionInList,
+  writeConnections,
+  writeSecureToken,
+} from './persist';
+import type { LynxRelayConfig } from './types';
+import { secureTokenKeyOf } from './urls';
+
+const testRelay: LynxRelayConfig = {
+  relayUrl: 'wss://relay.example/tunnel',
+  serverId: 'srv_test123',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' },
+};
+
+describe('connection persistence', () => {
+  test('migrates a pre-candidates entry to a single direct candidate', () => {
+    const store = createMemoryKvStore({
+      [CONNECTIONS_STORAGE_KEY]: JSON.stringify([
+        { id: 'a', label: 'Home', url: 'http://192.168.1.10:2606', lastUsedAt: 10, clientToken: 'tok-a' },
+        { id: 'b', label: 'Work', url: 'http://work.example', lastUsedAt: 5 },
+      ]),
+    });
+    const connections = readConnections(store);
+    expect(connections).toHaveLength(2);
+    const home = connections.find((connection) => connection.id === 'a')!;
+    expect(home.candidates).toEqual([{ kind: 'direct', url: 'http://192.168.1.10:2606' }]);
+    expect(home.hasToken).toBe(true);
+  });
+
+  test('persists LAN then relay in order and never writes the token into metadata', async () => {
+    const store = createMemoryKvStore();
+    const secure = createMemorySecureStore();
+    const candidates = [
+      { kind: 'direct' as const, url: 'http://192.168.1.5:2606' },
+      { kind: 'relay' as const, relay: testRelay },
+    ];
+    const next = upsertConnectionInList([], {
+      label: 'Both',
+      candidates,
+      hasToken: true,
+      now: 1,
+    });
+    writeConnections(store, next);
+    await writeSecureToken(secure, { candidates }, 'oc_client_secret');
+
+    const raw = JSON.parse(store.getItem(CONNECTIONS_STORAGE_KEY) || '[]') as Array<Record<string, unknown>>;
+    expect(raw[0]?.clientToken).toBeUndefined();
+    expect((raw[0]?.candidates as Array<{ kind: string }>).map((candidate) => candidate.kind)).toEqual(['direct', 'relay']);
+    const rawRelay = (raw[0]?.candidates as Array<Record<string, unknown>>)[1];
+    expect(Object.keys(rawRelay.relay as object).sort()).toEqual(['hostEncPubJwk', 'relayUrl', 'serverId']);
+    expect(await readSecureToken(secure, { candidates })).toBe('oc_client_secret');
+    expect(secureTokenKeyOf({ candidates })).toContain('relay:');
+    expect(prefixedTokenKey(secureTokenKeyOf({ candidates }))).toContain('token.');
+  });
+
+  test('drops a malformed legacy relay entry and keeps a valid direct one', () => {
+    const store = createMemoryKvStore({
+      [CONNECTIONS_STORAGE_KEY]: JSON.stringify([
+        { id: 'bad', label: 'Broken', lastUsedAt: 20, mode: 'relay', relay: { relayUrl: 'wss://relay.example' } },
+        { id: 'ok', label: 'Home', url: 'http://192.168.1.10:2606', lastUsedAt: 10 },
+      ]),
+    });
+    const connections = readConnections(store);
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.id).toBe('ok');
+  });
+
+  test('dedupes the same relay identity and keeps a different relay URL as a second instance', () => {
+    const first = upsertConnectionInList([], {
+      label: 'Stable',
+      candidates: [{ kind: 'relay', relay: testRelay }],
+      now: 1,
+    });
+    const renamed = upsertConnectionInList(first, {
+      label: 'Home Mac renamed',
+      candidates: [{ kind: 'relay', relay: testRelay }],
+      now: 2,
+    });
+    expect(renamed).toHaveLength(1);
+    expect(renamed[0]?.label).toBe('Home Mac renamed');
+
+    const other = upsertConnectionInList(renamed, {
+      label: 'Preview',
+      candidates: [{
+        kind: 'relay',
+        relay: { ...testRelay, relayUrl: 'wss://self-hosted.example/ws' },
+      }],
+      now: 3,
+    });
+    expect(other).toHaveLength(2);
+  });
+});

--- a/packages/lynx/src/connection/persist.ts
+++ b/packages/lynx/src/connection/persist.ts
@@ -1,0 +1,150 @@
+import { createUuid } from '../uuid';
+import { migrateLegacyCandidates, parseCandidate, serializeCandidate, candidateSetsMatch } from './candidates';
+import type { LynxKvStore, LynxSavedConnection, LynxSecureStore, LynxTransportCandidate } from './types';
+import { connectionDisplayUrl, getConnectionLabel, secureTokenKeyOf } from './urls';
+
+export const CONNECTIONS_STORAGE_KEY = 'openchamber.mobile.connections.v1';
+export const DEVICE_ID_STORAGE_KEY = 'openchamber.mobile.deviceId';
+export const SECURE_STORAGE_PREFIX = 'openchamber.mobile.';
+export const CONNECTIONS_LIMIT = 12;
+
+export const prefixedTokenKey = (key: string): string =>
+  `${SECURE_STORAGE_PREFIX}token.${encodeURIComponent(key)}`;
+
+export const readDeviceId = (store: LynxKvStore): string => {
+  const existing = store.getItem(DEVICE_ID_STORAGE_KEY);
+  if (existing && existing.trim()) return existing.trim();
+  const generated = createUuid();
+  store.setItem(DEVICE_ID_STORAGE_KEY, generated);
+  return generated;
+};
+
+export const mobileClientDedupeKey = (store: LynxKvStore): string => `mobile:${readDeviceId(store)}`;
+
+const readRawConnections = (store: LynxKvStore): unknown => {
+  try {
+    return JSON.parse(store.getItem(CONNECTIONS_STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+};
+
+export const readConnections = (store: LynxKvStore): LynxSavedConnection[] => {
+  const parsed = readRawConnections(store);
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .flatMap((item): LynxSavedConnection[] => {
+      if (!item || typeof item !== 'object') return [];
+      const record = item as Record<string, unknown>;
+      if (typeof record.id !== 'string') return [];
+      const candidates = Array.isArray(record.candidates)
+        ? record.candidates.map(parseCandidate).filter((candidate): candidate is LynxTransportCandidate => Boolean(candidate))
+        : migrateLegacyCandidates(record);
+      if (candidates.length === 0) return [];
+      const inlineToken = typeof record.clientToken === 'string' && record.clientToken.trim() ? record.clientToken : undefined;
+      const label = typeof record.label === 'string' && record.label.trim()
+        ? record.label
+        : getConnectionLabel(connectionDisplayUrl({ candidates }));
+      return [{
+        id: record.id,
+        label,
+        candidates,
+        lastUsedAt: typeof record.lastUsedAt === 'number' ? record.lastUsedAt : 0,
+        hasToken: Boolean(record.hasToken) || Boolean(inlineToken),
+      }];
+    })
+    .sort((left, right) => right.lastUsedAt - left.lastUsedAt);
+};
+
+export const writeConnections = (store: LynxKvStore, connections: LynxSavedConnection[]): void => {
+  const serialized = connections.slice(0, CONNECTIONS_LIMIT).map((connection) => ({
+    id: connection.id,
+    label: connection.label,
+    candidates: connection.candidates.map(serializeCandidate),
+    lastUsedAt: connection.lastUsedAt,
+    hasToken: Boolean(connection.hasToken),
+  }));
+  store.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(serialized));
+};
+
+export const upsertConnectionInList = (
+  connections: LynxSavedConnection[],
+  draft: {
+    id?: string;
+    label: string;
+    candidates: LynxTransportCandidate[];
+    hasToken?: boolean;
+    now?: number;
+  },
+): LynxSavedConnection[] => {
+  const existing = connections.find((item) => (
+    (draft.id && item.id === draft.id) || candidateSetsMatch(item.candidates, draft.candidates)
+  ));
+  const next: LynxSavedConnection = {
+    id: draft.id || existing?.id || createUuid(),
+    label: draft.label,
+    candidates: draft.candidates,
+    lastUsedAt: draft.now ?? Date.now(),
+    hasToken: draft.hasToken ?? existing?.hasToken ?? false,
+  };
+  return [
+    next,
+    ...connections.filter((item) => item.id !== next.id && !candidateSetsMatch(item.candidates, draft.candidates)),
+  ].slice(0, CONNECTIONS_LIMIT);
+};
+
+export const readSecureToken = async (
+  secure: LynxSecureStore,
+  connection: { candidates: LynxTransportCandidate[] },
+): Promise<string | undefined> => {
+  const key = secureTokenKeyOf(connection);
+  if (!key) return undefined;
+  const value = await secure.get(prefixedTokenKey(key));
+  return typeof value === 'string' && value.trim() ? value : undefined;
+};
+
+export const writeSecureToken = async (
+  secure: LynxSecureStore,
+  connection: { candidates: LynxTransportCandidate[] },
+  token: string,
+): Promise<boolean> => {
+  const key = secureTokenKeyOf(connection);
+  if (!key) return false;
+  return secure.set(prefixedTokenKey(key), token);
+};
+
+export const deleteSecureToken = async (
+  secure: LynxSecureStore,
+  connection: { candidates: LynxTransportCandidate[] },
+): Promise<void> => {
+  const key = secureTokenKeyOf(connection);
+  if (!key) return;
+  await secure.delete(prefixedTokenKey(key));
+};
+
+export const createMemoryKvStore = (initial?: Record<string, string>): LynxKvStore => {
+  const map = new Map(Object.entries(initial ?? {}));
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value);
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+  };
+};
+
+export const createMemorySecureStore = (): LynxSecureStore => {
+  const map = new Map<string, string>();
+  return {
+    get: async (key) => map.get(key),
+    set: async (key, value) => {
+      map.set(key, value);
+      return true;
+    },
+    delete: async (key) => {
+      map.delete(key);
+    },
+  };
+};

--- a/packages/lynx/src/connection/probe.test.ts
+++ b/packages/lynx/src/connection/probe.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'vitest';
+
+import { RELAY_RACE_HEADSTART_MS } from './http';
+import { probeConnectionCandidates, type ProbeDeps } from './probe';
+import type { LynxClock, LynxHttpResponse, LynxRelayConfig, LynxRequestInit } from './types';
+
+const relay: LynxRelayConfig = {
+  relayUrl: 'wss://relay.example/ws',
+  serverId: 'srv_home',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' },
+};
+
+const jsonResponse = (status: number, body: unknown): LynxHttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+const createClock = () => {
+  const sleeps: number[] = [];
+  const clock: LynxClock = {
+    now: () => 0,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  };
+  return { clock, sleeps };
+};
+
+describe('probeConnectionCandidates (connect race harness)', () => {
+  test('relay-only does not sleep the 1.5s LAN headstart', async () => {
+    const { clock, sleeps } = createClock();
+    const tunnelFetches: string[] = [];
+    const deps: ProbeDeps = {
+      http: { request: async () => jsonResponse(500, {}) },
+      clock,
+      nativeClient: true,
+      openRelayTunnel: () => ({
+        fetch: async (path) => {
+          tunnelFetches.push(path);
+          return jsonResponse(200, { authenticated: true, scope: 'client' });
+        },
+        close: () => undefined,
+      }),
+    };
+
+    const result = await probeConnectionCandidates(
+      [{ kind: 'relay', relay }],
+      'tok',
+      deps,
+    );
+
+    expect(result.status).toBe('ok');
+    expect(result.status === 'ok' ? result.transport.kind : null).toBe('relay');
+    expect(sleeps).not.toContain(RELAY_RACE_HEADSTART_MS);
+    expect(tunnelFetches).toEqual(['/auth/session']);
+  });
+
+  test('LAN success wins after a live /health + /auth/session (relay headstart is scheduled, not a Bonjour browse)', async () => {
+    const { clock, sleeps } = createClock();
+    const deps: ProbeDeps = {
+      http: {
+        request: async (url) => {
+          if (url.endsWith('/health')) return jsonResponse(200, { serverId: 'srv_home' });
+          if (url.endsWith('/auth/session')) return jsonResponse(200, { authenticated: true, scope: 'client' });
+          return jsonResponse(404, {});
+        },
+      },
+      clock,
+      nativeClient: true,
+      openRelayTunnel: () => ({
+        fetch: async () => new Promise<LynxHttpResponse>(() => undefined),
+        close: () => undefined,
+      }),
+    };
+
+    const result = await probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.20:4096' }, { kind: 'relay', relay }],
+      'tok',
+      deps,
+    );
+
+    expect(result).toEqual({ status: 'ok', transport: { kind: 'direct', url: 'http://192.168.1.20:4096' } });
+    expect(sleeps).toContain(RELAY_RACE_HEADSTART_MS);
+  });
+
+  test('dead LAN starts relay immediately (does not wait out a leftover headstart)', async () => {
+    const { clock } = createClock();
+    let resolveSleep: (() => void) | undefined;
+    const hangingClock: LynxClock = {
+      now: () => 0,
+      sleep: () => new Promise<void>((resolve) => {
+        resolveSleep = resolve;
+      }),
+    };
+    const deps: ProbeDeps = {
+      http: { request: async () => jsonResponse(503, {}) },
+      clock: hangingClock,
+      nativeClient: true,
+      openRelayTunnel: () => ({
+        fetch: async () => jsonResponse(200, { authenticated: true, scope: 'client' }),
+        close: () => undefined,
+      }),
+    };
+
+    const resultPromise = probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.20:4096' }, { kind: 'relay', relay }],
+      'tok',
+      deps,
+    );
+    const result = await resultPromise;
+    expect(result.status).toBe('ok');
+    expect(result.status === 'ok' ? result.transport.kind : null).toBe('relay');
+    resolveSleep?.();
+    void clock;
+  });
+
+  test('401 on LAN is needs-login for every transport (same token)', async () => {
+    const { clock } = createClock();
+    const deps: ProbeDeps = {
+      http: {
+        request: async (url) => {
+          if (url.endsWith('/health')) return jsonResponse(200, {});
+          return jsonResponse(401, { authenticated: false });
+        },
+      },
+      clock,
+      nativeClient: true,
+    };
+    const result = await probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.20:4096' }],
+      'expired',
+      deps,
+    );
+    expect(result).toEqual({ status: 'needs-login' });
+  });
+
+  test('skips a direct candidate whose /health serverId mismatches the paired relay', async () => {
+    const { clock } = createClock();
+    const seenAuth: string[] = [];
+    const deps: ProbeDeps = {
+      http: {
+        request: async (url, _init?: LynxRequestInit) => {
+          if (url.includes('192.168.1.20') && url.endsWith('/health')) {
+            return jsonResponse(200, { serverId: 'srv_other' });
+          }
+          if (url.endsWith('/auth/session')) {
+            seenAuth.push(url);
+            return jsonResponse(200, { authenticated: true, scope: 'client' });
+          }
+          return jsonResponse(503, {});
+        },
+      },
+      clock,
+      nativeClient: true,
+      openRelayTunnel: () => ({
+        fetch: async () => jsonResponse(200, { authenticated: true, scope: 'client' }),
+        close: () => undefined,
+      }),
+    };
+    const result = await probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.20:4096' }, { kind: 'relay', relay }],
+      'tok',
+      deps,
+    );
+    expect(seenAuth).toEqual([]);
+    expect(result.status === 'ok' ? result.transport.kind : null).toBe('relay');
+  });
+
+  test('native without a client-scoped token is needs-login even when a cookie session is present', async () => {
+    const { clock } = createClock();
+    const deps: ProbeDeps = {
+      http: {
+        request: async (url) => {
+          if (url.endsWith('/health')) return jsonResponse(200, {});
+          return jsonResponse(200, { authenticated: true, scope: 'session' });
+        },
+      },
+      clock,
+      nativeClient: true,
+    };
+    const result = await probeConnectionCandidates(
+      [{ kind: 'direct', url: 'http://192.168.1.20:4096' }],
+      undefined,
+      deps,
+    );
+    expect(result).toEqual({ status: 'needs-login' });
+  });
+});

--- a/packages/lynx/src/connection/probe.ts
+++ b/packages/lynx/src/connection/probe.ts
@@ -1,0 +1,244 @@
+import {
+  FAST_PROBE_TIMEOUT_MS,
+  RELAY_CONNECT_TIMEOUT_MS,
+  RELAY_RACE_HEADSTART_MS,
+  raceWithTimeout,
+  readSessionStatus,
+  requestWithTimeout,
+} from './http';
+import type {
+  LynxChosenTransport,
+  LynxClock,
+  LynxHttpClient,
+  LynxRelayConfig,
+  LynxRelayTunnel,
+  LynxRelayTunnelFactory,
+  LynxTransportCandidate,
+} from './types';
+import { normalizeConnectionUrl, relayCandidateOf } from './urls';
+
+export type ProbeResult =
+  | { status: 'ok'; transport: LynxChosenTransport }
+  | { status: 'needs-login' }
+  | { status: 'unreachable' };
+
+export type ProbeDeps = {
+  http: LynxHttpClient;
+  clock: LynxClock;
+  openRelayTunnel?: LynxRelayTunnelFactory;
+  nativeClient?: boolean;
+};
+
+type RelayProbeOutcome = 'ok' | 'needs-login' | 'auth-failed' | 'unreachable';
+
+const probeRelaySession = async (
+  deps: ProbeDeps,
+  relay: LynxTransportCandidate & { kind: 'relay' },
+  token: string | undefined,
+  grant: string | undefined,
+  timeoutMs: number,
+): Promise<{ outcome: RelayProbeOutcome; tunnel?: LynxRelayTunnel }> => {
+  if (!deps.openRelayTunnel) return { outcome: 'unreachable' };
+  const tunnel = deps.openRelayTunnel(relay.relay, grant);
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+  const session = await raceWithTimeout(
+    timeoutMs,
+    tunnel.fetch('/auth/session', { headers }).catch(() => null),
+  );
+  const finish = (outcome: RelayProbeOutcome) => {
+    if (outcome !== 'ok') tunnel.close();
+    return { outcome, tunnel: outcome === 'ok' ? tunnel : undefined };
+  };
+  if (!session) return finish('unreachable');
+  if (session.status === 401) return finish(token ? 'auth-failed' : 'needs-login');
+  if (!session.ok && session.status !== 404) return finish('auth-failed');
+  const status = await readSessionStatus(session);
+  if (status && status.disabled !== true && status.authenticated === false) {
+    return finish(token ? 'auth-failed' : 'needs-login');
+  }
+  return finish('ok');
+};
+
+const probeDirectChain = async (
+  deps: ProbeDeps,
+  directs: Array<{ kind: 'direct'; url: string }>,
+  token: string | undefined,
+  expectedServerId: string | null,
+  requestOptions?: { totalTimeoutMs?: number },
+): Promise<ProbeResult> => {
+  for (const candidate of directs) {
+    const url = normalizeConnectionUrl(candidate.url) || candidate.url;
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+    const health = await requestWithTimeout(deps.http, `${url}/health`, { method: 'GET' }, requestOptions);
+    if (!health?.ok) continue;
+    if (expectedServerId) {
+      const payload = await health.json().catch(() => null);
+      const reported = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).serverId : null;
+      if (typeof reported === 'string' && reported && reported !== expectedServerId) continue;
+    }
+    const session = await requestWithTimeout(
+      deps.http,
+      `${url}/auth/session`,
+      { method: 'GET', headers },
+      requestOptions,
+    );
+    if (session?.status === 401) return { status: 'needs-login' };
+    if (!session || (!session.ok && session.status !== 404)) continue;
+    const status = await readSessionStatus(session);
+    if (status && status.disabled !== true && status.authenticated === false) return { status: 'needs-login' };
+    const authDisabled = status?.disabled === true;
+    if (!token && deps.nativeClient && !authDisabled && status?.scope !== 'client') {
+      return { status: 'needs-login' };
+    }
+    return { status: 'ok', transport: { kind: 'direct', url } };
+  }
+  return { status: 'unreachable' };
+};
+
+export const probeConnectionCandidates = async (
+  candidates: LynxTransportCandidate[],
+  token: string | undefined,
+  deps: ProbeDeps,
+  options?: { fast?: boolean },
+): Promise<ProbeResult> => {
+  const requestOptions = options?.fast ? { totalTimeoutMs: FAST_PROBE_TIMEOUT_MS } : undefined;
+  const expectedServerId = relayCandidateOf({ candidates })?.serverId ?? null;
+  const relayCandidate = candidates.find((candidate): candidate is Extract<LynxTransportCandidate, { kind: 'relay' }> => (
+    candidate.kind === 'relay'
+  )) ?? null;
+  const directList = candidates.filter((candidate): candidate is Extract<LynxTransportCandidate, { kind: 'direct' }> => (
+    candidate.kind === 'direct'
+  ));
+
+  const probeRelay = async (): Promise<ProbeResult> => {
+    if (!relayCandidate) return { status: 'unreachable' };
+    const { outcome, tunnel } = await probeRelaySession(
+      deps,
+      relayCandidate,
+      token,
+      undefined,
+      options?.fast ? FAST_PROBE_TIMEOUT_MS : RELAY_CONNECT_TIMEOUT_MS,
+    );
+    if (outcome === 'ok') {
+      tunnel?.close();
+      return { status: 'ok', transport: { kind: 'relay', relay: relayCandidate.relay } };
+    }
+    if (outcome === 'needs-login' || outcome === 'auth-failed') return { status: 'needs-login' };
+    return { status: 'unreachable' };
+  };
+
+  if (!relayCandidate) return probeDirectChain(deps, directList, token, expectedServerId, requestOptions);
+  if (directList.length === 0) return probeRelay();
+
+  return new Promise<ProbeResult>((resolve) => {
+    let settled = false;
+    let relayCancelled = false;
+    let relayStarted = false;
+    let directResult: ProbeResult | null = null;
+    let relayResult: ProbeResult | null = null;
+    let headstartDone = false;
+
+    const finish = (result: ProbeResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    const startRelayProbe = () => {
+      if (relayCancelled || settled || relayStarted) return;
+      relayStarted = true;
+      void probeRelay().then((result) => {
+        relayResult = result;
+        if (settled || relayCancelled) return;
+        if (result.status === 'ok' || result.status === 'needs-login') {
+          finish(result);
+          return;
+        }
+        if (directResult) finish(directResult);
+      });
+    };
+
+    void probeDirectChain(deps, directList, token, expectedServerId, requestOptions).then((result) => {
+      directResult = result;
+      if (settled) return;
+      if (result.status === 'ok' || result.status === 'needs-login') {
+        relayCancelled = true;
+        finish(result);
+        return;
+      }
+      if (relayResult) {
+        finish(relayResult);
+        return;
+      }
+      startRelayProbe();
+    });
+
+    void deps.clock.sleep(RELAY_RACE_HEADSTART_MS).then(() => {
+      headstartDone = true;
+      if (!headstartDone) return;
+      startRelayProbe();
+    });
+  });
+};
+
+export type LiveTransport =
+  | { kind: 'direct'; url: string }
+  | { kind: 'relay'; relay: LynxRelayConfig; tunnel: LynxRelayTunnel };
+
+export const establishLiveTransport = async (
+  candidates: LynxTransportCandidate[],
+  deps: ProbeDeps,
+): Promise<LiveTransport | null> => {
+  const expectedServerId = relayCandidateOf({ candidates })?.serverId ?? null;
+  for (const candidate of candidates) {
+    if (candidate.kind === 'relay') {
+      if (!deps.openRelayTunnel) continue;
+      const tunnel = deps.openRelayTunnel(candidate.relay);
+      const health = await raceWithTimeout(
+        RELAY_CONNECT_TIMEOUT_MS,
+        tunnel.fetch('/health').catch(() => null),
+      );
+      if (health?.ok) return { kind: 'relay', relay: candidate.relay, tunnel };
+      tunnel.close();
+      continue;
+    }
+    const url = normalizeConnectionUrl(candidate.url) || candidate.url;
+    const health = await requestWithTimeout(deps.http, `${url}/health`, { method: 'GET' });
+    if (!health?.ok) continue;
+    if (expectedServerId) {
+      const payload = await health.json().catch(() => null);
+      const reported = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).serverId : null;
+      if (typeof reported === 'string' && reported && reported !== expectedServerId) continue;
+    }
+    return { kind: 'direct', url };
+  }
+  return null;
+};
+
+export const validateMobileConnectionSession = async (
+  input: { url: string; clientToken?: string | null },
+  deps: ProbeDeps,
+  options?: { fast?: boolean },
+): Promise<boolean> => {
+  let url = '';
+  try {
+    url = normalizeConnectionUrl(input.url);
+  } catch {
+    return false;
+  }
+  if (!url) return false;
+  const token = input.clientToken?.trim() || undefined;
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+  const requestOptions = options?.fast ? { totalTimeoutMs: FAST_PROBE_TIMEOUT_MS } : undefined;
+  const health = await requestWithTimeout(deps.http, `${url}/health`, { method: 'GET' }, requestOptions);
+  if (!health?.ok) return false;
+  const session = await requestWithTimeout(
+    deps.http,
+    `${url}/auth/session`,
+    { method: 'GET', headers },
+    requestOptions,
+  );
+  if (!session || (!session.ok && session.status !== 404)) return false;
+  const status = await readSessionStatus(session);
+  return !(status && status.disabled !== true && status.authenticated === false);
+};

--- a/packages/lynx/src/connection/types.ts
+++ b/packages/lynx/src/connection/types.ts
@@ -1,0 +1,112 @@
+export type LynxConnectionMode = 'direct' | 'relay';
+
+export type LynxRelayConfig = {
+  relayUrl: string;
+  serverId: string;
+  hostEncPubJwk: JsonWebKey;
+};
+
+export type LynxTransportCandidate =
+  | { kind: 'direct'; url: string }
+  | { kind: 'relay'; relay: LynxRelayConfig };
+
+export type LynxSavedConnection = {
+  id: string;
+  label: string;
+  candidates: LynxTransportCandidate[];
+  lastUsedAt: number;
+  hasToken?: boolean;
+};
+
+export type LynxPendingConnection = {
+  id: string;
+  label: string;
+  candidates: LynxTransportCandidate[];
+  relay?: LynxRelayConfig;
+  relayGrant?: string;
+};
+
+export type LynxConnectInput = {
+  id?: string;
+  url?: string;
+  candidates?: LynxTransportCandidate[];
+  clientToken?: string;
+  label?: string;
+  relay?: LynxRelayConfig;
+  relayGrant?: string;
+};
+
+export type LynxConnectError =
+  | 'url-required'
+  | 'unreachable'
+  | 'auth-required'
+  | 'invalid-url'
+  | 'password-failed'
+  | 'secure-store-failed';
+
+export type LynxChosenTransport =
+  | { kind: 'direct'; url: string }
+  | { kind: 'relay'; relay: LynxRelayConfig };
+
+export type LynxConnectResult =
+  | { status: 'connected'; connection: LynxSavedConnection; transport: LynxChosenTransport; runtimeKey: string }
+  | { status: 'needs-login'; pending: LynxPendingConnection }
+  | { status: 'failed'; error: LynxConnectError };
+
+export type LynxHttpResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+};
+
+export type LynxRequestInit = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  signal?: AbortSignal;
+};
+
+export type LynxHttpClient = {
+  request: (url: string, init?: LynxRequestInit) => Promise<LynxHttpResponse | null>;
+};
+
+export type LynxRelayTunnel = {
+  fetch: (path: string, init?: LynxRequestInit) => Promise<LynxHttpResponse | null>;
+  close: () => void;
+};
+
+export type LynxRelayTunnelFactory = (
+  relay: LynxRelayConfig,
+  grant?: string,
+) => LynxRelayTunnel;
+
+export type LynxSecureStore = {
+  get: (key: string) => Promise<string | undefined>;
+  set: (key: string, value: string) => Promise<boolean>;
+  delete: (key: string) => Promise<void>;
+};
+
+export type LynxKvStore = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem?: (key: string) => void;
+};
+
+export type LynxClock = {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+};
+
+export type LynxDevicePlatform = 'ios' | 'android';
+
+export type LynxRuntimeIdentity = {
+  runtimeKey: string;
+  clientToken: string | null;
+  transport: LynxChosenTransport;
+};
+
+export type LynxSessionStatus = {
+  authenticated?: boolean;
+  disabled?: boolean;
+  scope?: string;
+};

--- a/packages/lynx/src/connection/urls.ts
+++ b/packages/lynx/src/connection/urls.ts
@@ -1,0 +1,64 @@
+import type { LynxRelayConfig, LynxTransportCandidate } from './types';
+
+export const normalizeConnectionUrl = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  const url = new URL(withScheme);
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/+$/, '');
+};
+
+export const getConnectionLabel = (url: string): string => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+};
+
+export const getConnectionStorageKey = (url: string): string => {
+  try {
+    return normalizeConnectionUrl(url);
+  } catch {
+    return url.trim().replace(/\/+$/g, '');
+  }
+};
+
+export const isSameConnectionUrl = (left: string, right: string): boolean =>
+  getConnectionStorageKey(left) === getConnectionStorageKey(right);
+
+export const relayConnectionRuntimeKey = (relay: LynxRelayConfig): string =>
+  `relay:${relay.serverId}@${relay.relayUrl.trim()}`;
+
+export const canonicalRelayUrl = (relay: LynxRelayConfig): string => `relay://${relay.serverId}`;
+
+export const directCandidates = (
+  connection: { candidates: LynxTransportCandidate[] },
+): Array<{ kind: 'direct'; url: string }> =>
+  connection.candidates.filter((candidate): candidate is { kind: 'direct'; url: string } => candidate.kind === 'direct');
+
+export const relayCandidateOf = (
+  connection: { candidates: LynxTransportCandidate[] },
+): LynxRelayConfig | null => {
+  const found = connection.candidates.find((candidate) => candidate.kind === 'relay');
+  return found && found.kind === 'relay' ? found.relay : null;
+};
+
+export const connectionDisplayUrl = (connection: { candidates: LynxTransportCandidate[] }): string => {
+  const direct = directCandidates(connection)[0];
+  if (direct) return direct.url;
+  const relay = relayCandidateOf(connection);
+  return relay ? canonicalRelayUrl(relay) : '';
+};
+
+export const secureTokenKeyOf = (connection: { candidates: LynxTransportCandidate[] }): string => {
+  const relay = relayCandidateOf(connection);
+  if (relay) return relayConnectionRuntimeKey(relay);
+  const direct = directCandidates(connection)[0];
+  return direct ? getConnectionStorageKey(direct.url) : '';
+};
+
+export const mobileConnectionKey = secureTokenKeyOf;

--- a/packages/lynx/src/deep-links/intents.test.ts
+++ b/packages/lynx/src/deep-links/intents.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildPairingConnectionPayload, encodePairingConnectionPayload } from '../pairing/payload';
+import { buildDeepLink, parseDeepLink } from './intents';
+
+const pairing = buildPairingConnectionPayload({
+  pairingId: 'pair_deep_link',
+  secret: 'one-time-secret',
+  candidates: [{ type: 'lan', url: 'http://192.168.1.20:4096' }],
+});
+
+describe('parseDeepLink', () => {
+  test('parses a v2 connect link and rejects v1', () => {
+    expect(parseDeepLink(encodePairingConnectionPayload(pairing))).toEqual({ type: 'connect', pairing });
+    expect(parseDeepLink('openchamber://connect?v=2&p=not-json')).toBeNull();
+    expect(parseDeepLink('openchamber://connect?v=1&server=https%3A%2F%2Fexample.com&token=secret')).toBeNull();
+  });
+
+  test('parses session, new-session, open-project, and sessions filters', () => {
+    expect(parseDeepLink('openchamber://session/ses_1?directory=/tmp/demo')).toEqual({
+      type: 'session',
+      sessionId: 'ses_1',
+      directory: '/tmp/demo',
+    });
+    expect(parseDeepLink('openchamber://new-session?directory=/tmp/demo&prompt=hello%20world')).toEqual({
+      type: 'new-session',
+      directory: '/tmp/demo',
+      projectId: undefined,
+      agent: undefined,
+      model: undefined,
+      prompt: 'hello world',
+    });
+    expect(parseDeepLink('openchamber://open-project?directory=/tmp/demo')).toEqual({
+      type: 'open-project',
+      directory: '/tmp/demo',
+    });
+    expect(parseDeepLink('openchamber://project/%2Ftmp%2Fdemo')).toEqual({
+      type: 'open-project',
+      directory: '/tmp/demo',
+    });
+    expect(parseDeepLink('openchamber://sessions?filter=attention')).toEqual({
+      type: 'sessions',
+      filter: 'attention',
+    });
+  });
+
+  test('parses status, settings, changes, and view overlays', () => {
+    expect(parseDeepLink('openchamber://status')).toEqual({ type: 'status' });
+    expect(parseDeepLink('openchamber://settings/instances')).toEqual({ type: 'settings', section: 'instances' });
+    expect(parseDeepLink('openchamber://changes/src/a.ts?staged=true')).toEqual({
+      type: 'changes',
+      path: 'src/a.ts',
+      staged: true,
+    });
+    expect(parseDeepLink('openchamber://view/files')).toEqual({ type: 'view', target: 'files' });
+    expect(parseDeepLink('openchamber://view/mcp')).toEqual({ type: 'view', target: 'mcp' });
+    expect(parseDeepLink('openchamber://view/instances')).toEqual({ type: 'view', target: 'instances' });
+    expect(parseDeepLink('openchamber://view/update')).toEqual({ type: 'view', target: 'update' });
+    expect(parseDeepLink('openchamber://view/changes')).toEqual({ type: 'changes' });
+  });
+
+  test('accepts legacy dir= and path= aliases', () => {
+    expect(parseDeepLink('openchamber://new-session?dir=/legacy')).toMatchObject({ directory: '/legacy' });
+    expect(parseDeepLink('openchamber://new-session?path=/codex')).toMatchObject({ directory: '/codex' });
+  });
+});
+
+describe('buildDeepLink', () => {
+  test('rebuilds canonical connect and navigation links', () => {
+    expect(buildDeepLink({ type: 'connect', pairing })).toBe(encodePairingConnectionPayload(pairing));
+    expect(buildDeepLink({ type: 'new-session', directory: '/tmp/demo', prompt: 'ship it' })).toBe(
+      'openchamber://new-session?directory=%2Ftmp%2Fdemo&prompt=ship+it',
+    );
+    expect(buildDeepLink({ type: 'open-project', directory: '/tmp/demo' })).toBe(
+      'openchamber://open-project?directory=%2Ftmp%2Fdemo',
+    );
+    expect(buildDeepLink({ type: 'session', sessionId: 'ses_1', directory: '/repo' })).toBe(
+      'openchamber://session/ses_1?directory=%2Frepo',
+    );
+  });
+});

--- a/packages/lynx/src/deep-links/intents.ts
+++ b/packages/lynx/src/deep-links/intents.ts
@@ -1,0 +1,160 @@
+import {
+  encodePairingConnectionPayload,
+  parsePairingConnectionPayload,
+  type PairingConnectionPayload,
+} from '../pairing/payload';
+
+export const DEEP_LINK_SCHEME = 'openchamber';
+
+export type SessionsFilter = 'all' | 'attention' | 'recent';
+export type ViewTarget = 'files' | 'mcp' | 'instances' | 'update';
+
+export type DeepLinkIntent =
+  | { type: 'connect'; pairing: PairingConnectionPayload }
+  | { type: 'session'; sessionId: string; directory?: string }
+  | { type: 'new-session'; directory?: string; projectId?: string; agent?: string; model?: string; prompt?: string }
+  | { type: 'open-project'; directory: string }
+  | { type: 'sessions'; filter?: SessionsFilter }
+  | { type: 'status' }
+  | { type: 'settings'; section?: string }
+  | { type: 'changes'; path?: string; staged?: boolean }
+  | { type: 'view'; target: ViewTarget };
+
+const trimSlashes = (value: string): string => value.replace(/^\/+|\/+$/g, '');
+
+const readDirectoryParam = (query: URLSearchParams): string | undefined => {
+  const value = query.get('directory') || query.get('dir') || query.get('path');
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const segmentsOf = (url: URL): string[] => {
+  const pathSegments = trimSlashes(url.pathname).split('/').filter(Boolean);
+  if (url.host) return [url.host, ...pathSegments];
+  return pathSegments;
+};
+
+export function parseDeepLink(raw: string | null | undefined, nowMs: number = Date.now()): DeepLinkIntent | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== `${DEEP_LINK_SCHEME}:`) return null;
+
+  const segments = segmentsOf(url);
+  const route = (segments[0] ?? '').toLowerCase();
+  const rest = segments.slice(1);
+  const query = url.searchParams;
+
+  switch (route) {
+    case 'connect': {
+      const pairing = parsePairingConnectionPayload(raw, nowMs);
+      return pairing ? { type: 'connect', pairing } : null;
+    }
+    case 'session': {
+      const sessionId = rest[0] || query.get('id') || '';
+      if (!sessionId) return null;
+      return { type: 'session', sessionId, directory: readDirectoryParam(query) };
+    }
+    case 'new':
+    case 'new-session': {
+      const prompt = query.get('prompt')?.trim();
+      return {
+        type: 'new-session',
+        directory: readDirectoryParam(query),
+        projectId: query.get('project') ?? undefined,
+        agent: query.get('agent') ?? undefined,
+        model: query.get('model') ?? undefined,
+        prompt: prompt || undefined,
+      };
+    }
+    case 'project':
+    case 'open-project': {
+      let fromPath: string | undefined;
+      if (rest.length > 0) {
+        try {
+          fromPath = decodeURIComponent(rest.join('/'));
+        } catch {
+          fromPath = rest.join('/');
+        }
+      }
+      const directory = readDirectoryParam(query) || fromPath;
+      if (!directory) return null;
+      return { type: 'open-project', directory };
+    }
+    case 'sessions': {
+      const filter = query.get('filter');
+      return {
+        type: 'sessions',
+        filter: filter === 'attention' || filter === 'recent' || filter === 'all' ? filter : undefined,
+      };
+    }
+    case 'status':
+      return { type: 'status' };
+    case 'settings':
+      return { type: 'settings', section: rest[0] || query.get('section') || undefined };
+    case 'changes':
+      return {
+        type: 'changes',
+        path: rest.join('/') || query.get('path') || undefined,
+        staged: query.get('staged') === 'true',
+      };
+    case 'view': {
+      const target = (rest[0] || '').toLowerCase();
+      if (target === 'changes') return { type: 'changes' };
+      if (target === 'files' || target === 'mcp' || target === 'instances' || target === 'update') {
+        return { type: 'view', target };
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function buildDeepLink(intent: DeepLinkIntent): string {
+  const base = `${DEEP_LINK_SCHEME}://`;
+  const withQuery = (path: string, params: Record<string, string | undefined>): string => {
+    const search = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (typeof value === 'string' && value.length > 0) search.set(key, value);
+    }
+    const query = search.toString();
+    return query ? `${base}${path}?${query}` : `${base}${path}`;
+  };
+
+  switch (intent.type) {
+    case 'connect':
+      return encodePairingConnectionPayload(intent.pairing);
+    case 'session':
+      return withQuery(`session/${encodeURIComponent(intent.sessionId)}`, { directory: intent.directory });
+    case 'new-session':
+      return withQuery('new-session', {
+        directory: intent.directory,
+        project: intent.projectId,
+        agent: intent.agent,
+        model: intent.model,
+        prompt: intent.prompt,
+      });
+    case 'open-project':
+      return withQuery('open-project', { directory: intent.directory });
+    case 'sessions':
+      return withQuery('sessions', { filter: intent.filter });
+    case 'status':
+      return `${base}status`;
+    case 'settings':
+      return intent.section ? `${base}settings/${encodeURIComponent(intent.section)}` : `${base}settings`;
+    case 'changes':
+      return withQuery(intent.path ? `changes/${intent.path}` : 'changes', {
+        staged: intent.staged ? 'true' : undefined,
+      });
+    case 'view':
+      return `${base}view/${intent.target}`;
+  }
+}

--- a/packages/lynx/src/index.ts
+++ b/packages/lynx/src/index.ts
@@ -1,0 +1,109 @@
+export {
+  buildPairingConnectionPayload,
+  encodePairingConnectionPayload,
+  parsePairingConnectionPayload,
+  parsePairingConnectionPayloadString,
+  type PairingConnectionPayload,
+  type PairingEndpointCandidate,
+  type PairingDirectCandidate,
+  type PairingRelayCandidate,
+} from './pairing/payload';
+export {
+  parseConnectionPayload,
+  type LynxConnectionPayload,
+  type LynxPairingPayload,
+} from './pairing/scan';
+export {
+  DEEP_LINK_SCHEME,
+  parseDeepLink,
+  buildDeepLink,
+  type DeepLinkIntent,
+  type SessionsFilter,
+  type ViewTarget,
+} from './deep-links/intents';
+export {
+  normalizeConnectionUrl,
+  getConnectionLabel,
+  connectionDisplayUrl,
+  relayConnectionRuntimeKey,
+  secureTokenKeyOf,
+  mobileConnectionKey,
+  isSameConnectionUrl,
+} from './connection/urls';
+export {
+  pairingCandidatesToMobile,
+  buildCandidatesFromInput,
+  candidateSetsMatch,
+  parseRelayConfig,
+} from './connection/candidates';
+export {
+  RELAY_RACE_HEADSTART_MS,
+  CONNECT_TIMEOUT_MS,
+  FAST_PROBE_TIMEOUT_MS,
+} from './connection/http';
+export {
+  probeConnectionCandidates,
+  establishLiveTransport,
+  validateMobileConnectionSession,
+  type ProbeResult,
+  type ProbeDeps,
+} from './connection/probe';
+export {
+  createLynxConnectionClient,
+  type LynxConnectionClient,
+  type LynxConnectionClientDeps,
+} from './connection/client';
+export {
+  createMemoryKvStore,
+  createMemorySecureStore,
+  CONNECTIONS_STORAGE_KEY,
+  DEVICE_ID_STORAGE_KEY,
+} from './connection/persist';
+export type {
+  LynxSavedConnection,
+  LynxTransportCandidate,
+  LynxRelayConfig,
+  LynxConnectInput,
+  LynxConnectResult,
+  LynxPendingConnection,
+  LynxHttpClient,
+  LynxHttpResponse,
+  LynxSecureStore,
+  LynxKvStore,
+  LynxClock,
+  LynxRuntimeIdentity,
+  LynxRelayTunnel,
+  LynxRelayTunnelFactory,
+} from './connection/types';
+export { createRuntimeIdentityStore, type LynxRuntimeIdentityStore } from './runtime/identity';
+export { createRuntimeFetch, isRuntimeServicePath, type LynxRuntimeFetch } from './runtime/fetch';
+export {
+  loadSessionIndexSnapshot,
+  lookupSessionIndexById,
+  pinSession,
+  unpinSession,
+  startSessionIndexBackgroundSync,
+} from './session-index/api';
+export {
+  createLynxSessionIndexStore,
+  createSessionIndexHomeBindings,
+  type LynxSessionIndexStore,
+} from './session-index/store';
+export { normalizePath } from './path';
+export {
+  projectSessionIndexHome,
+  formatHomeSessionSubtitle,
+  getProjectLabel,
+  getSessionActivityUpdatedAt,
+  type LynxProjectsHomeModel,
+  type LynxHomeProject,
+  type LynxHomeSessionRow,
+} from './session-index/homeModel';
+export type {
+  SessionIndexSnapshot,
+  SessionIndexSession,
+  SessionIndexDirectory,
+  SessionIndexLoadResult,
+  SessionIndexState,
+  SessionIndexLookupHit,
+} from './session-index/types';

--- a/packages/lynx/src/pairing/payload.test.ts
+++ b/packages/lynx/src/pairing/payload.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildPairingConnectionPayload,
+  encodePairingConnectionPayload,
+  parsePairingConnectionPayload,
+} from './payload';
+
+const hostEncPubJwk = { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' } as const;
+
+describe('pairing v2 payload', () => {
+  test('round-trips v2 pairing payloads with direct candidates', () => {
+    const payload = buildPairingConnectionPayload({
+      pairingId: 'pair_123',
+      secret: 'one-time-secret',
+      label: 'Desktop',
+      fingerprint: 'ABCD-1234',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      candidates: [
+        { type: 'lan', url: 'http://192.168.1.20:4096/', priority: 20 },
+        { type: 'tunnel', url: 'https://runtime.example/', priority: 10 },
+      ],
+    });
+    const encoded = encodePairingConnectionPayload(payload);
+    expect(encoded.startsWith('openchamber://connect?v=2&p=')).toBe(true);
+    expect(parsePairingConnectionPayload(encoded)).toEqual({
+      ...payload,
+      candidates: [
+        { type: 'lan', url: 'http://192.168.1.20:4096', priority: 20 },
+        { type: 'tunnel', url: 'https://runtime.example', priority: 10 },
+      ],
+    });
+  });
+
+  test('round-trips a relay candidate (transport, not a URL)', () => {
+    const payload = buildPairingConnectionPayload({
+      pairingId: 'pair_relay',
+      secret: 'one-time-secret',
+      candidates: [
+        { type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 },
+        { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv_abc', hostEncPubJwk, priority: 30 },
+      ],
+    });
+    const parsed = parsePairingConnectionPayload(encodePairingConnectionPayload(payload));
+    expect(parsed?.candidates).toEqual([
+      { type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 },
+      { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv_abc', hostEncPubJwk, priority: 30 },
+    ]);
+  });
+
+  test('rejects legacy v1 token links', () => {
+    expect(parsePairingConnectionPayload('openchamber://connect?v=1&server=https://runtime.example&token=t')).toBeNull();
+  });
+
+  test('rejects missing secret and invalid json', () => {
+    expect(parsePairingConnectionPayload('openchamber://connect?v=2&p=not-json')).toBeNull();
+    const missingSecret = Buffer.from(JSON.stringify({
+      v: 2,
+      pairingId: 'pair_123',
+      candidates: [{ type: 'lan', url: 'http://runtime.example' }],
+    })).toString('base64url');
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${missingSecret}`)).toBeNull();
+  });
+
+  test('drops a private-key member from a relay JWK', () => {
+    const withKey = Buffer.from(JSON.stringify({
+      v: 2,
+      pairingId: 'pair_1',
+      secret: 's',
+      candidates: [{
+        type: 'relay',
+        relayUrl: 'wss://relay.example/ws',
+        serverId: 'srv',
+        hostEncPubJwk: { ...hostEncPubJwk, d: 'PRIVATE' },
+      }],
+    })).toString('base64url');
+    const parsed = parsePairingConnectionPayload(`openchamber://connect?v=2&p=${withKey}`);
+    expect(parsed?.candidates[0]).toEqual({
+      type: 'relay',
+      relayUrl: 'wss://relay.example/ws',
+      serverId: 'srv',
+      hostEncPubJwk,
+    });
+  });
+
+  test('rejects relay userinfo credentials and non-ws URLs', () => {
+    const encodeCandidates = (candidates: unknown[]) =>
+      Buffer.from(JSON.stringify({ v: 2, pairingId: 'pair_1', secret: 's', candidates })).toString('base64url');
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${encodeCandidates([{
+      type: 'relay',
+      relayUrl: 'https://relay.example/ws',
+      serverId: 'srv',
+      hostEncPubJwk,
+    }])}`)).toBeNull();
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${encodeCandidates([{
+      type: 'relay',
+      relayUrl: 'wss://user:pass@relay.example/ws',
+      serverId: 'srv',
+      hostEncPubJwk,
+    }])}`)).toBeNull();
+  });
+
+  test('rejects an expired payload', () => {
+    const expired = Buffer.from(JSON.stringify({
+      v: 2,
+      pairingId: 'pair_1',
+      secret: 's',
+      expiresAt: '2000-01-01T00:00:00.000Z',
+      candidates: [{ type: 'lan', url: 'http://192.168.1.1:4096' }],
+    })).toString('base64url');
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${expired}`)).toBeNull();
+  });
+});

--- a/packages/lynx/src/pairing/payload.ts
+++ b/packages/lynx/src/pairing/payload.ts
@@ -1,0 +1,236 @@
+const MAX_PAIRING_PAYLOAD_LENGTH = 16_384;
+
+export type PairingDirectCandidate = {
+  type: 'lan' | 'tunnel';
+  url: string;
+  priority?: number;
+};
+
+export type PairingRelayCandidate = {
+  type: 'relay';
+  relayUrl: string;
+  serverId: string;
+  hostEncPubJwk: JsonWebKey;
+  grant?: string;
+  priority?: number;
+};
+
+export type PairingEndpointCandidate = PairingDirectCandidate | PairingRelayCandidate;
+
+export type PairingConnectionPayload = {
+  v: 2;
+  pairingId: string;
+  secret: string;
+  label?: string;
+  fingerprint?: string;
+  expiresAt?: string;
+  candidates: PairingEndpointCandidate[];
+};
+
+const globalWithBuffer = globalThis as typeof globalThis & {
+  Buffer?: {
+    from: (value: string, encoding?: string) => { toString: (encoding: string) => string };
+  };
+};
+
+const base64UrlEncode = (value: string): string => {
+  if (globalWithBuffer.Buffer) {
+    return globalWithBuffer.Buffer.from(value, 'utf8').toString('base64url');
+  }
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.slice(i, i + 0x8000));
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+const base64UrlDecode = (value: string): string | null => {
+  try {
+    if (globalWithBuffer.Buffer) {
+      return globalWithBuffer.Buffer.from(value, 'base64url').toString('utf8');
+    }
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(value.length / 4) * 4, '=');
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+};
+
+const normalizeHttpUrl = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    parsed.hash = '';
+    return parsed.toString().replace(/\/+$/g, '');
+  } catch {
+    return null;
+  }
+};
+
+const normalizeWsUrl = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') return null;
+    if (parsed.username || parsed.password) return null;
+    parsed.username = '';
+    parsed.password = '';
+    parsed.hash = '';
+    parsed.search = '';
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+};
+
+const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.length > 0;
+
+const normalizeEcPublicJwk = (value: unknown): JsonWebKey | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const jwk = value as Record<string, unknown>;
+  if (jwk.kty !== 'EC' || jwk.crv !== 'P-256') return null;
+  if (!isNonEmptyString(jwk.x) || !isNonEmptyString(jwk.y)) return null;
+  return { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y };
+};
+
+const normalizePriority = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+const normalizePairingCandidate = (value: unknown): PairingEndpointCandidate | null => {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const priority = normalizePriority(record.priority);
+
+  if (record.type === 'lan' || record.type === 'tunnel') {
+    const url = normalizeHttpUrl(record.url);
+    if (!url) return null;
+    return priority === undefined ? { type: record.type, url } : { type: record.type, url, priority };
+  }
+
+  if (record.type === 'relay') {
+    const relayUrl = normalizeWsUrl(record.relayUrl);
+    if (!relayUrl) return null;
+    const serverId = typeof record.serverId === 'string' ? record.serverId.trim() : '';
+    if (!serverId) return null;
+    const hostEncPubJwk = normalizeEcPublicJwk(record.hostEncPubJwk);
+    if (!hostEncPubJwk) return null;
+    const grant = typeof record.grant === 'string' && record.grant.trim() ? record.grant.trim() : undefined;
+    return {
+      type: 'relay',
+      relayUrl,
+      serverId,
+      hostEncPubJwk,
+      ...(grant ? { grant } : {}),
+      ...(priority === undefined ? {} : { priority }),
+    };
+  }
+
+  return null;
+};
+
+export const normalizePairingPayload = (value: unknown, nowMs: number = Date.now()): PairingConnectionPayload | null => {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (record.v !== 2) return null;
+  const pairingId = typeof record.pairingId === 'string' ? record.pairingId.trim() : '';
+  const secret = typeof record.secret === 'string' ? record.secret.trim() : '';
+  if (!pairingId || !secret) return null;
+  const candidates = Array.isArray(record.candidates)
+    ? record.candidates.map(normalizePairingCandidate).filter((candidate): candidate is PairingEndpointCandidate => Boolean(candidate))
+    : [];
+  if (candidates.length === 0) return null;
+  const expiresAt = typeof record.expiresAt === 'string' && record.expiresAt.trim() ? record.expiresAt.trim() : undefined;
+  if (expiresAt) {
+    const expiresTime = Date.parse(expiresAt);
+    if (!Number.isFinite(expiresTime) || expiresTime <= nowMs) return null;
+  }
+  const label = typeof record.label === 'string' && record.label.trim() ? record.label.trim() : undefined;
+  const fingerprint = typeof record.fingerprint === 'string' && record.fingerprint.trim() ? record.fingerprint.trim() : undefined;
+  return {
+    v: 2,
+    pairingId,
+    secret,
+    ...(label ? { label } : {}),
+    ...(fingerprint ? { fingerprint } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    candidates,
+  };
+};
+
+export const buildPairingConnectionPayload = (input: Omit<PairingConnectionPayload, 'v'>): PairingConnectionPayload => ({
+  v: 2,
+  pairingId: input.pairingId.trim(),
+  secret: input.secret.trim(),
+  ...(input.label?.trim() ? { label: input.label.trim() } : {}),
+  ...(input.fingerprint?.trim() ? { fingerprint: input.fingerprint.trim() } : {}),
+  ...(input.expiresAt?.trim() ? { expiresAt: input.expiresAt.trim() } : {}),
+  candidates: input.candidates,
+});
+
+export const encodePairingConnectionPayload = (payload: PairingConnectionPayload): string => {
+  const normalized = normalizePairingPayload(payload);
+  if (!normalized) throw new Error('Invalid pairing connection payload');
+  const params = new URLSearchParams();
+  params.set('v', '2');
+  params.set('p', base64UrlEncode(JSON.stringify(normalized)));
+  return `openchamber://connect?${params.toString()}`;
+};
+
+export const parsePairingConnectionPayloadString = (
+  value: string,
+  nowMs: number = Date.now(),
+): PairingConnectionPayload | null => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  const question = trimmed.indexOf('?');
+  if (question === -1 || !/^openchamber:\/\/connect\/?$/i.test(trimmed.slice(0, question))) return null;
+  let version: string | null = null;
+  let encoded: string | null = null;
+  for (const part of trimmed.slice(question + 1).split('&')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const key = part.slice(0, eq);
+    const raw = part.slice(eq + 1);
+    if (key === 'v') version = raw;
+    else if (key === 'p') encoded = raw;
+  }
+  if (version !== '2' || !encoded || encoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  const decoded = base64UrlDecode(encoded);
+  if (!decoded || decoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  try {
+    return normalizePairingPayload(JSON.parse(decoded) as unknown, nowMs);
+  } catch {
+    return null;
+  }
+};
+
+export const parsePairingConnectionPayload = (
+  value: string,
+  nowMs: number = Date.now(),
+): PairingConnectionPayload | null => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === 'openchamber:' && url.hostname === 'connect') {
+      if (url.searchParams.get('v') !== '2') return null;
+      const encoded = url.searchParams.get('p') || '';
+      if (!encoded || encoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+      const decoded = base64UrlDecode(encoded);
+      if (!decoded || decoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+      return normalizePairingPayload(JSON.parse(decoded) as unknown, nowMs);
+    }
+  } catch {
+    // Some hosts throw on this scheme; fall through to the string parser.
+  }
+  return parsePairingConnectionPayloadString(trimmed, nowMs);
+};

--- a/packages/lynx/src/pairing/scan.test.ts
+++ b/packages/lynx/src/pairing/scan.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildPairingConnectionPayload, encodePairingConnectionPayload } from './payload';
+import { parseConnectionPayload } from './scan';
+
+describe('parseConnectionPayload', () => {
+  test('accepts a bare http(s) server URL', () => {
+    expect(parseConnectionPayload('https://oc.example')).toEqual({ url: 'https://oc.example' });
+    expect(parseConnectionPayload('  http://192.168.1.10:2606 ')).toEqual({ url: 'http://192.168.1.10:2606' });
+  });
+
+  test('accepts a v2 pairing link', () => {
+    const pairing = buildPairingConnectionPayload({
+      pairingId: 'pair_scan',
+      secret: 'one-time-secret',
+      candidates: [{ type: 'lan', url: 'http://192.168.1.20:4096' }],
+    });
+    expect(parseConnectionPayload(encodePairingConnectionPayload(pairing))).toEqual({ pairing });
+  });
+
+  test('rejects non-connection, session, and legacy v1 payloads', () => {
+    expect(parseConnectionPayload('')).toBeNull();
+    expect(parseConnectionPayload('hello world')).toBeNull();
+    expect(parseConnectionPayload('openchamber://connect')).toBeNull();
+    expect(parseConnectionPayload('openchamber://session/abc')).toBeNull();
+    expect(parseConnectionPayload('openchamber://connect?v=1&server=http%3A%2F%2F192.168.1.10%3A2606&token=tok')).toBeNull();
+    expect(parseConnectionPayload('openchamber://connect?v=1&mode=relay#offer=eyJ2IjoxfQ')).toBeNull();
+  });
+});

--- a/packages/lynx/src/pairing/scan.ts
+++ b/packages/lynx/src/pairing/scan.ts
@@ -1,0 +1,35 @@
+import {
+  parsePairingConnectionPayload,
+  type PairingConnectionPayload,
+} from './payload';
+
+export type LynxConnectionPayload = {
+  url: string;
+  clientToken?: string;
+  label?: string;
+};
+
+export type LynxPairingPayload = {
+  pairing: PairingConnectionPayload;
+};
+
+/**
+ * QR / paste parser. Accepts a pairing v2 `openchamber://connect?v=2&p=` link
+ * or a bare http(s) server URL. Legacy v1 token links and other schemes are
+ * rejected — there is no Nearby / Bonjour browse path.
+ */
+export const parseConnectionPayload = (
+  raw: string,
+  nowMs: number = Date.now(),
+): LynxConnectionPayload | LynxPairingPayload | null => {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (/^openchamber:\/\//i.test(trimmed)) {
+    const pairing = parsePairingConnectionPayload(trimmed, nowMs);
+    return pairing ? { pairing } : null;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) return { url: trimmed };
+  return null;
+};

--- a/packages/lynx/src/path.ts
+++ b/packages/lynx/src/path.ts
@@ -1,0 +1,4 @@
+/** Lynx-owned path display normalizer. Do not import `@/lib/pathNormalization`. */
+export const normalizePath = (value?: string | null): string =>
+  // eslint-disable-next-line no-restricted-syntax -- Lynx cannot import the UI path helper.
+  (value || '').replace(/\\/g, '/').replace(/\/+$/g, '');

--- a/packages/lynx/src/runtime/fetch.ts
+++ b/packages/lynx/src/runtime/fetch.ts
@@ -1,0 +1,53 @@
+import type { LynxHttpClient, LynxHttpResponse, LynxRelayTunnel, LynxRequestInit } from '../connection/types';
+import type { LynxRuntimeIdentityStore } from './identity';
+
+const RUNTIME_PATHS = [/^\/api(?:\/|$)/, /^\/auth(?:\/|$)/, /^\/health$/];
+
+export const isRuntimeServicePath = (path: string): boolean =>
+  RUNTIME_PATHS.some((pattern) => pattern.test(path));
+
+export type LynxRuntimeFetch = (
+  path: string,
+  init?: LynxRequestInit,
+) => Promise<LynxHttpResponse>;
+
+export type RuntimeFetchDeps = {
+  http: LynxHttpClient;
+  identity: LynxRuntimeIdentityStore;
+  getRelayTunnel?: () => LynxRelayTunnel | null;
+};
+
+/**
+ * OpenChamber-owned HTTP. Paths like `/health`, `/auth/session`, and
+ * `/api/openchamber/…` ride the active runtime (direct URL or injected relay
+ * tunnel). Capture identity at call time — do not cache the base URL.
+ */
+export const createRuntimeFetch = (deps: RuntimeFetchDeps): LynxRuntimeFetch => {
+  return async (path, init) => {
+    const identity = deps.identity.get();
+    if (!identity) {
+      return { ok: false, status: 0, json: async () => ({ error: 'no-runtime' }) };
+    }
+    const headers = { ...init?.headers };
+    if (identity.clientToken && !headers.Authorization) {
+      headers.Authorization = `Bearer ${identity.clientToken}`;
+    }
+    const nextInit = { ...init, headers };
+
+    if (identity.transport.kind === 'relay') {
+      const tunnel = deps.getRelayTunnel?.();
+      if (!tunnel) {
+        return { ok: false, status: 0, json: async () => ({ error: 'relay-tunnel-unavailable' }) };
+      }
+      const response = await tunnel.fetch(path, nextInit);
+      return response ?? { ok: false, status: 0, json: async () => ({ error: 'relay-unreachable' }) };
+    }
+
+    const base = identity.transport.url.replace(/\/+$/, '');
+    const response = await deps.http.request(`${base}${path}`, nextInit);
+    if (!response) {
+      return { ok: false, status: 0, json: async () => ({ error: 'unreachable' }) };
+    }
+    return response;
+  };
+};

--- a/packages/lynx/src/runtime/identity.ts
+++ b/packages/lynx/src/runtime/identity.ts
@@ -1,0 +1,37 @@
+import type { LynxChosenTransport, LynxRuntimeIdentity } from '../connection/types';
+
+export type RuntimeIdentityListener = (identity: LynxRuntimeIdentity | null) => void;
+
+export const createRuntimeIdentityStore = () => {
+  let current: LynxRuntimeIdentity | null = null;
+  const listeners = new Set<RuntimeIdentityListener>();
+
+  const notify = () => {
+    for (const listener of listeners) listener(current);
+  };
+
+  return {
+    get: (): LynxRuntimeIdentity | null => current,
+    set: (identity: LynxRuntimeIdentity): void => {
+      current = identity;
+      notify();
+    },
+    switchToTransport: (transport: LynxChosenTransport, clientToken: string | null, runtimeKey: string): LynxRuntimeIdentity => {
+      current = { runtimeKey, clientToken, transport };
+      notify();
+      return current;
+    },
+    clear: (): void => {
+      current = null;
+      notify();
+    },
+    subscribe: (listener: RuntimeIdentityListener): (() => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+};
+
+export type LynxRuntimeIdentityStore = ReturnType<typeof createRuntimeIdentityStore>;

--- a/packages/lynx/src/session-index/api.test.ts
+++ b/packages/lynx/src/session-index/api.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest';
+
+import { loadSessionIndexSnapshot, lookupSessionIndexById, pinSession } from './api';
+import type { LynxHttpResponse } from '../connection/types';
+
+const snapshot = {
+  available: true,
+  revision: 4,
+  sync: {
+    active: false,
+    completed: 1,
+    total: 1,
+    pendingDirectories: [],
+    completedDirectories: ['/repo'],
+    failedDirectories: [],
+  },
+  directories: [{
+    directory: '/repo',
+    cursor: null,
+    hasMore: false,
+    lastSyncedAt: 1,
+    lastFullSyncedAt: 1,
+    lastAccessedAt: 1,
+    sessions: [{
+      id: 'ses_1',
+      title: 'Fix login',
+      directory: '/repo',
+      time: { created: 1, updated: 2 },
+    }],
+  }],
+  pinnedSessionIds: ['ses_1'],
+};
+
+const jsonResponse = (status: number, body: unknown): LynxHttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+describe('session-index API', () => {
+  test('loads an authoritative snapshot from GET /api/openchamber/session-index', async () => {
+    const result = await loadSessionIndexSnapshot(async (path) => {
+      expect(path).toBe('/api/openchamber/session-index');
+      return jsonResponse(200, snapshot);
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.snapshot.revision).toBe(4);
+    expect(result.snapshot.pinnedSessionIds).toEqual(['ses_1']);
+  });
+
+  test('treats 501 as unsupported, not an empty catalog', async () => {
+    const result = await loadSessionIndexSnapshot(async () => jsonResponse(501, { error: 'unavailable' }));
+    expect(result).toEqual({ status: 'unsupported' });
+  });
+
+  test('failed GET is failed, not an empty success', async () => {
+    const result = await loadSessionIndexSnapshot(async () => jsonResponse(500, { error: 'boom' }));
+    expect(result.status).toBe('failed');
+    if (result.status !== 'failed') return;
+    expect(result.previous).toBeNull();
+  });
+
+  test('available:false is not an empty success', async () => {
+    const result = await loadSessionIndexSnapshot(async () => jsonResponse(200, { available: false, directories: [] }));
+    expect(result.status).toBe('failed');
+  });
+
+  test('lookup and pin use the real session-index routes', async () => {
+    const paths: string[] = [];
+    const fetch = async (path: string, init?: { method?: string }) => {
+      paths.push(`${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/session/ses_1') && !path.endsWith('/pin')) {
+        return jsonResponse(200, { available: true, session: { id: 'ses_1', directory: '/repo', title: 'Fix login' } });
+      }
+      return jsonResponse(204, {});
+    };
+    expect(await lookupSessionIndexById(fetch, 'ses_1')).toEqual({
+      id: 'ses_1',
+      directory: '/repo',
+      title: 'Fix login',
+      parentID: null,
+    });
+    await pinSession(fetch, 'ses_1');
+    expect(paths).toEqual([
+      'GET /api/openchamber/session-index/session/ses_1',
+      'POST /api/openchamber/session-index/session/ses_1/pin',
+    ]);
+  });
+});

--- a/packages/lynx/src/session-index/api.ts
+++ b/packages/lynx/src/session-index/api.ts
@@ -1,0 +1,108 @@
+import type { LynxRuntimeFetch } from '../runtime/fetch';
+import { parseSessionIndexSnapshot } from './parse';
+import type { SessionIndexLoadResult, SessionIndexLookupHit, SessionIndexSnapshot } from './types';
+
+const ensureOk = async (response: { ok: boolean; status: number }): Promise<void> => {
+  if (response.ok) return;
+  throw new Error(`session index request failed (${response.status})`);
+};
+
+export const loadSessionIndexSnapshot = async (
+  runtimeFetch: LynxRuntimeFetch,
+  options?: { signal?: AbortSignal },
+): Promise<SessionIndexLoadResult> => {
+  try {
+    const response = await runtimeFetch('/api/openchamber/session-index', { signal: options?.signal });
+    if (response.status === 501) return { status: 'unsupported' };
+    await ensureOk(response);
+    const payload = await response.json() as Partial<SessionIndexSnapshot> & { available?: boolean };
+    const snapshot = parseSessionIndexSnapshot(payload);
+    if (!snapshot) {
+      return { status: 'failed', error: new Error('session index snapshot unavailable'), previous: null };
+    }
+    return { status: 'ok', snapshot };
+  } catch (error) {
+    return {
+      status: 'failed',
+      error: error instanceof Error ? error : new Error(String(error)),
+      previous: null,
+    };
+  }
+};
+
+export const lookupSessionIndexById = async (
+  runtimeFetch: LynxRuntimeFetch,
+  sessionId: string,
+  options?: { signal?: AbortSignal },
+): Promise<SessionIndexLookupHit | null> => {
+  const id = sessionId.trim();
+  if (!id) return null;
+  try {
+    const response = await runtimeFetch(
+      `/api/openchamber/session-index/session/${encodeURIComponent(id)}`,
+      { signal: options?.signal },
+    );
+    if (response.status === 404 || response.status === 501) return null;
+    await ensureOk(response);
+    const payload = await response.json() as {
+      available?: boolean;
+      session?: { id?: string; directory?: string; title?: string; parentID?: string | null };
+    };
+    if (payload.available !== true || !payload.session) return null;
+    const directory = typeof payload.session.directory === 'string' ? payload.session.directory.trim() : '';
+    const sid = typeof payload.session.id === 'string' ? payload.session.id : id;
+    if (!directory) return null;
+    return {
+      id: sid,
+      directory,
+      title: typeof payload.session.title === 'string' ? payload.session.title : undefined,
+      parentID: payload.session.parentID ?? null,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const pinSession = async (
+  runtimeFetch: LynxRuntimeFetch,
+  sessionId: string,
+  options?: { signal?: AbortSignal },
+): Promise<void> => {
+  const id = sessionId.trim();
+  if (!id) throw new Error('session index pin requires a session id');
+  const response = await runtimeFetch(
+    `/api/openchamber/session-index/session/${encodeURIComponent(id)}/pin`,
+    { method: 'POST', signal: options?.signal },
+  );
+  if (response.status === 501) throw new Error('session index pin is unsupported');
+  await ensureOk(response);
+};
+
+export const unpinSession = async (
+  runtimeFetch: LynxRuntimeFetch,
+  sessionId: string,
+  options?: { signal?: AbortSignal },
+): Promise<void> => {
+  const id = sessionId.trim();
+  if (!id) throw new Error('session index unpin requires a session id');
+  const response = await runtimeFetch(
+    `/api/openchamber/session-index/session/${encodeURIComponent(id)}/pin`,
+    { method: 'DELETE', signal: options?.signal },
+  );
+  if (response.status === 501) throw new Error('session index unpin is unsupported');
+  await ensureOk(response);
+};
+
+export const startSessionIndexBackgroundSync = async (
+  runtimeFetch: LynxRuntimeFetch,
+  directories: string[],
+): Promise<SessionIndexSnapshot | null> => {
+  const response = await runtimeFetch('/api/openchamber/session-index/sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ directories }),
+  });
+  if (response.status === 501) return null;
+  await ensureOk(response);
+  return response.json() as Promise<SessionIndexSnapshot>;
+};

--- a/packages/lynx/src/session-index/cache.ts
+++ b/packages/lynx/src/session-index/cache.ts
@@ -1,0 +1,71 @@
+import type { LynxKvStore } from '../connection/types';
+import { isSessionIndexSnapshot } from './parse';
+import type { SessionIndexSnapshot } from './types';
+
+const CACHE_VERSION = 1;
+const STORAGE_KEY = 'oc.sessionIndexStartupCache';
+const MAX_RUNTIME_ENTRIES = 8;
+const MAX_CACHE_BYTES = 1_000_000;
+
+type SessionIndexCache = {
+  version: 1;
+  entries: Record<string, SessionIndexSnapshot>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const parseCache = (raw: string | null): SessionIndexCache | null => {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.version !== CACHE_VERSION || !isRecord(parsed.entries)) return null;
+    return { version: CACHE_VERSION, entries: parsed.entries as Record<string, SessionIndexSnapshot> };
+  } catch {
+    return null;
+  }
+};
+
+export const readSessionIndexStartupSnapshot = (
+  runtimeKey: string,
+  storage: LynxKvStore,
+): SessionIndexSnapshot | null => {
+  if (!runtimeKey) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  const parsed = parseCache(raw);
+  if (!parsed) return null;
+  const entry = parsed.entries[runtimeKey];
+  return isSessionIndexSnapshot(entry) ? entry : null;
+};
+
+export const writeSessionIndexStartupSnapshot = (
+  runtimeKey: string,
+  snapshot: SessionIndexSnapshot,
+  storage: LynxKvStore,
+): void => {
+  if (!runtimeKey || !isSessionIndexSnapshot(snapshot)) return;
+  let raw: string | null = null;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+  } catch {
+    return;
+  }
+  const parsed = parseCache(raw);
+  const entries = { ...(parsed?.entries ?? {}), [runtimeKey]: snapshot };
+  const retainedKeys = Object.keys(entries).slice(-MAX_RUNTIME_ENTRIES);
+  const retainedEntries = Object.fromEntries(
+    retainedKeys.map((key) => [key, entries[key]!]),
+  ) as Record<string, SessionIndexSnapshot>;
+  try {
+    const serialized = JSON.stringify({ version: CACHE_VERSION, entries: retainedEntries });
+    if (serialized.length > MAX_CACHE_BYTES) return;
+    storage.setItem(STORAGE_KEY, serialized);
+  } catch {
+    // Cold-start cache is optional; live fetch result is authoritative.
+  }
+};

--- a/packages/lynx/src/session-index/homeModel.test.ts
+++ b/packages/lynx/src/session-index/homeModel.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatHomeSessionSubtitle, projectSessionIndexHome } from './homeModel';
+import type { SessionIndexSnapshot } from './types';
+
+const snapshot = (overrides?: Partial<SessionIndexSnapshot>): SessionIndexSnapshot => ({
+  revision: 1,
+  sync: {
+    active: false,
+    completed: 1,
+    total: 1,
+    pendingDirectories: [],
+    completedDirectories: ['/Users/dev/openchamber'],
+    failedDirectories: [],
+  },
+  directories: [{
+    directory: '/Users/dev/openchamber',
+    cursor: null,
+    hasMore: false,
+    lastSyncedAt: 1,
+    lastFullSyncedAt: 1,
+    lastAccessedAt: 1,
+    sessions: [
+      {
+        id: 'ses_root',
+        title: 'Wire pairing',
+        directory: '/Users/dev/openchamber',
+        time: { created: 1, updated: 10 },
+        metadata: { openchamber: { titleRefresh: { activityUpdatedAt: 10 }, sessionStatus: { type: 'busy' } } },
+      },
+      {
+        id: 'ses_child',
+        title: 'subagent',
+        directory: '/Users/dev/openchamber',
+        parentID: 'ses_root',
+        time: { created: 2, updated: 11 },
+      },
+      {
+        id: 'ses_old',
+        title: 'Older root',
+        directory: '/Users/dev/openchamber',
+        time: { created: 1, updated: 3 },
+        metadata: { openchamber: { titleRefresh: { activityUpdatedAt: 3 }, sessionStatus: { type: 'idle' } } },
+      },
+      {
+        id: 'ses_archived',
+        title: 'Gone',
+        directory: '/Users/dev/openchamber',
+        time: { created: 1, updated: 2, archived: 9 },
+      },
+    ],
+  }],
+  pinnedSessionIds: ['ses_old'],
+  ...overrides,
+});
+
+describe('Projects home session-index projection', () => {
+  test('formats 项目 · 分支 the same way as Cap', () => {
+    expect(formatHomeSessionSubtitle('openchamber', 'main')).toBe('openchamber · main');
+    expect(formatHomeSessionSubtitle('openchamber')).toBe('openchamber');
+  });
+
+  test('uses directory order activity, omits children and archived roots, and splits pinned / in-progress', () => {
+    const model = projectSessionIndexHome(snapshot(), {
+      worktreeBranchByDirectory: { '/Users/dev/openchamber': 'work/lynx-native' },
+    });
+    expect(model.projects).toHaveLength(1);
+    expect(model.projects[0]?.label).toBe('openchamber');
+    expect(model.projects[0]?.sessions.map((row) => row.id)).toEqual(['ses_root']);
+    expect(model.projects[0]?.sessions[0]?.subtitle).toBe('openchamber · work/lynx-native');
+    expect(model.pinnedSessions.map((row) => row.id)).toEqual(['ses_old']);
+    expect(model.inProgressSessions.map((row) => row.id)).toEqual(['ses_root']);
+    expect(model.sessionById.has('ses_child')).toBe(true);
+  });
+
+  test('does not invent rows when the snapshot has empty directories', () => {
+    const model = projectSessionIndexHome({
+      ...snapshot(),
+      directories: [{
+        directory: '/empty',
+        cursor: null,
+        hasMore: false,
+        lastSyncedAt: 1,
+        lastFullSyncedAt: 1,
+        lastAccessedAt: 1,
+        sessions: [],
+      }],
+      pinnedSessionIds: [],
+    });
+    expect(model.projects[0]?.sessionCount).toBe(0);
+    expect(model.pinnedSessions).toEqual([]);
+    expect(model.inProgressSessions).toEqual([]);
+  });
+});

--- a/packages/lynx/src/session-index/homeModel.ts
+++ b/packages/lynx/src/session-index/homeModel.ts
@@ -1,0 +1,131 @@
+import { normalizePath } from '../path';
+import type { SessionIndexSession, SessionIndexSnapshot } from './types';
+
+export const formatHomeSessionSubtitle = (
+  projectLabel: string,
+  branch?: string | null,
+): string => {
+  const trimmedBranch = branch?.trim();
+  return trimmedBranch ? `${projectLabel} · ${trimmedBranch}` : projectLabel;
+};
+
+export const getProjectLabel = (path: string, label?: string | null): string => {
+  if (label?.trim()) return label.trim();
+  const normalized = normalizePath(path);
+  if (!normalized) return '';
+  const segments = normalized.split('/').filter(Boolean);
+  return segments[segments.length - 1] || normalized;
+};
+
+export const getSessionActivityUpdatedAt = (session: SessionIndexSession): number => {
+  const activity = session.metadata?.openchamber?.titleRefresh?.activityUpdatedAt;
+  if (typeof activity === 'number' && Number.isFinite(activity) && activity > 0) return activity;
+  const updated = session.time.updated;
+  if (typeof updated === 'number' && Number.isFinite(updated) && updated > 0) return updated;
+  return typeof session.time.created === 'number' && Number.isFinite(session.time.created) ? session.time.created : 0;
+};
+
+const getParentId = (session: SessionIndexSession): string | null => session.parentID ?? null;
+
+const isArchived = (session: SessionIndexSession): boolean =>
+  typeof session.time.archived === 'number' && session.time.archived > 0;
+
+const sessionStatus = (session: SessionIndexSession): string =>
+  session.metadata?.openchamber?.sessionStatus?.type ?? 'idle';
+
+export type LynxHomeSessionRow = {
+  id: string;
+  directory: string;
+  title: string;
+  subtitle?: string;
+  activityAt: number;
+  pinned: boolean;
+  archived: boolean;
+  inProgress: boolean;
+};
+
+export type LynxHomeProject = {
+  id: string;
+  label: string;
+  path: string;
+  sessionCount: number;
+  latestActivity: number;
+  sessions: LynxHomeSessionRow[];
+};
+
+export type LynxProjectsHomeModel = {
+  projects: LynxHomeProject[];
+  pinnedSessions: LynxHomeSessionRow[];
+  inProgressSessions: LynxHomeSessionRow[];
+  sessionById: Map<string, SessionIndexSession>;
+};
+
+export type ProjectSessionIndexHomeOptions = {
+  untitledLabel?: string;
+  projectLabels?: Record<string, string>;
+  worktreeBranchByDirectory?: Record<string, string>;
+};
+
+const toRow = (
+  session: SessionIndexSession,
+  pinnedIds: ReadonlySet<string>,
+  options: ProjectSessionIndexHomeOptions,
+): LynxHomeSessionRow => {
+  const path = normalizePath(session.directory);
+  const projectLabel = getProjectLabel(path, options.projectLabels?.[path]);
+  const branch = options.worktreeBranchByDirectory?.[path];
+  return {
+    id: session.id,
+    directory: path,
+    title: session.title.trim() || options.untitledLabel || 'Untitled',
+    subtitle: formatHomeSessionSubtitle(projectLabel, branch),
+    activityAt: getSessionActivityUpdatedAt(session),
+    pinned: pinnedIds.has(session.id),
+    archived: isArchived(session),
+    inProgress: sessionStatus(session) !== 'idle' && sessionStatus(session) !== '',
+  };
+};
+
+/**
+ * Projects-home projection from an authoritative session-index snapshot.
+ * Root rows only (no parentID). Order is activity descending — the index
+ * already ranks that way; we re-apply so callers do not sort by id.
+ */
+export const projectSessionIndexHome = (
+  snapshot: SessionIndexSnapshot,
+  options: ProjectSessionIndexHomeOptions = {},
+): LynxProjectsHomeModel => {
+  const pinnedIds = new Set(snapshot.pinnedSessionIds ?? []);
+  const sessionById = new Map<string, SessionIndexSession>();
+  const projects: LynxHomeProject[] = [];
+
+  for (const directory of snapshot.directories) {
+    const path = normalizePath(directory.directory);
+    const roots = directory.sessions
+      .filter((session) => !getParentId(session) && !isArchived(session) && !pinnedIds.has(session.id))
+      .slice()
+      .sort((left, right) => getSessionActivityUpdatedAt(right) - getSessionActivityUpdatedAt(left));
+    for (const session of directory.sessions) sessionById.set(session.id, session);
+    const rows = roots.map((session) => toRow(session, pinnedIds, options));
+    const latestActivity = rows.reduce((max, row) => Math.max(max, row.activityAt), 0);
+    projects.push({
+      id: path,
+      label: getProjectLabel(path, options.projectLabels?.[path]),
+      path,
+      sessionCount: rows.length,
+      latestActivity,
+      sessions: rows,
+    });
+  }
+
+  const allRoots = projects.flatMap((project) => project.sessions);
+  const pinnedSessions = (snapshot.pinnedSessionIds ?? [])
+    .map((id) => {
+      const session = sessionById.get(id);
+      return session ? toRow(session, pinnedIds, options) : null;
+    })
+    .filter((row): row is LynxHomeSessionRow => Boolean(row));
+  const inProgressSessions = allRoots.filter((row) => row.inProgress && !row.pinned);
+
+  return { projects, pinnedSessions, inProgressSessions, sessionById };
+};

--- a/packages/lynx/src/session-index/parse.ts
+++ b/packages/lynx/src/session-index/parse.ts
@@ -1,0 +1,77 @@
+import type { SessionIndexSnapshot } from './types';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+
+const isSessionIndexSync = (value: unknown): value is SessionIndexSnapshot['sync'] => {
+  if (!isRecord(value)) return false;
+  if (typeof value.active !== 'boolean') return false;
+  if (typeof value.completed !== 'number' || !Number.isFinite(value.completed)) return false;
+  if (typeof value.total !== 'number' || !Number.isFinite(value.total)) return false;
+  if (!isStringArray(value.pendingDirectories)) return false;
+  if (!isStringArray(value.completedDirectories)) return false;
+  if (!isStringArray(value.failedDirectories)) return false;
+  if (value.enriching !== undefined && typeof value.enriching !== 'boolean') return false;
+  return true;
+};
+
+const isSessionIndexSession = (value: unknown): boolean => (
+  isRecord(value)
+  && typeof value.id === 'string'
+  && value.id.length > 0
+  && typeof value.title === 'string'
+  && typeof value.directory === 'string'
+  && value.directory.length > 0
+  && isRecord(value.time)
+  && typeof value.time.created === 'number'
+  && Number.isFinite(value.time.created)
+  && typeof value.time.updated === 'number'
+  && Number.isFinite(value.time.updated)
+);
+
+const isSessionIndexDirectory = (value: unknown): boolean => {
+  if (!isRecord(value)) return false;
+  if (typeof value.directory !== 'string' || !value.directory.trim()) return false;
+  if (value.cursor !== null && (typeof value.cursor !== 'number' || !Number.isFinite(value.cursor))) return false;
+  if (typeof value.hasMore !== 'boolean') return false;
+  if (typeof value.lastSyncedAt !== 'number' || !Number.isFinite(value.lastSyncedAt)) return false;
+  if (typeof value.lastFullSyncedAt !== 'number' || !Number.isFinite(value.lastFullSyncedAt)) return false;
+  if (typeof value.lastAccessedAt !== 'number' || !Number.isFinite(value.lastAccessedAt)) return false;
+  return Array.isArray(value.sessions) && value.sessions.every(isSessionIndexSession);
+};
+
+export const isSessionIndexSnapshot = (value: unknown): value is SessionIndexSnapshot => {
+  if (!isRecord(value)) return false;
+  if (typeof value.revision !== 'number' || !Number.isFinite(value.revision)) return false;
+  if (!isSessionIndexSync(value.sync)) return false;
+  if (!Array.isArray(value.directories)) return false;
+  if (value.pinnedSessionIds !== undefined && !isStringArray(value.pinnedSessionIds)) return false;
+  return value.directories.every(isSessionIndexDirectory);
+};
+
+export const parseSessionIndexSnapshot = (
+  payload: Partial<SessionIndexSnapshot> & { available?: boolean },
+): SessionIndexSnapshot | null => {
+  if (payload.available !== true || !Array.isArray(payload.directories)) return null;
+  const pinnedSessionIds = Array.isArray(payload.pinnedSessionIds)
+    ? payload.pinnedSessionIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    : undefined;
+  const snapshot = {
+    revision: typeof payload.revision === 'number' ? payload.revision : 0,
+    sync: payload.sync ?? {
+      active: false,
+      completed: 0,
+      total: 0,
+      pendingDirectories: [],
+      completedDirectories: [],
+      failedDirectories: [],
+      enriching: false,
+    },
+    directories: payload.directories,
+    ...(pinnedSessionIds ? { pinnedSessionIds } : {}),
+  };
+  return isSessionIndexSnapshot(snapshot) ? snapshot : null;
+};

--- a/packages/lynx/src/session-index/store.test.ts
+++ b/packages/lynx/src/session-index/store.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+
+import { createMemoryKvStore } from '../connection/persist';
+import { createLynxSessionIndexStore } from './store';
+import type { SessionIndexSnapshot } from './types';
+import type { LynxHttpResponse } from '../connection/types';
+
+const okSnapshot: SessionIndexSnapshot = {
+  revision: 2,
+  sync: {
+    active: false,
+    completed: 1,
+    total: 1,
+    pendingDirectories: [],
+    completedDirectories: ['/repo'],
+    failedDirectories: [],
+  },
+  directories: [{
+    directory: '/repo',
+    cursor: null,
+    hasMore: false,
+    lastSyncedAt: 1,
+    lastFullSyncedAt: 1,
+    lastAccessedAt: 1,
+    sessions: [{
+      id: 'ses_1',
+      title: 'Keep me',
+      directory: '/repo',
+      time: { created: 1, updated: 2 },
+    }],
+  }],
+  pinnedSessionIds: [],
+};
+
+const jsonResponse = (status: number, body: unknown): LynxHttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+describe('session-index store', () => {
+  test('failed refresh preserves the previous snapshot', async () => {
+    let fail = false;
+    const store = createLynxSessionIndexStore({
+      getRuntimeKey: () => 'runtime-a',
+      storage: createMemoryKvStore(),
+      runtimeFetch: async () => {
+        if (fail) return jsonResponse(500, { error: 'down' });
+        return jsonResponse(200, { available: true, ...okSnapshot });
+      },
+    });
+    const first = await store.load();
+    expect(first.status).toBe('ok');
+    fail = true;
+    const second = await store.refresh();
+    expect(second.status).toBe('failed');
+    if (second.status !== 'failed') return;
+    expect(second.previous?.directories[0]?.sessions[0]?.id).toBe('ses_1');
+    expect(store.getState().snapshot?.directories[0]?.sessions[0]?.id).toBe('ses_1');
+    expect(store.getState().status).toBe('failed');
+  });
+
+  test('runtime switch clears in-memory rows so another instance cannot reuse them', async () => {
+    let runtimeKey = 'runtime-a';
+    const store = createLynxSessionIndexStore({
+      getRuntimeKey: () => runtimeKey,
+      storage: createMemoryKvStore(),
+      runtimeFetch: async () => jsonResponse(200, { available: true, ...okSnapshot }),
+    });
+    await store.load();
+    expect(store.getState().snapshot).not.toBeNull();
+    runtimeKey = 'runtime-b';
+    store.clearForRuntimeChange();
+    expect(store.getState().snapshot).toBeNull();
+    expect(store.getState().status).toBe('idle');
+  });
+});

--- a/packages/lynx/src/session-index/store.ts
+++ b/packages/lynx/src/session-index/store.ts
@@ -1,0 +1,131 @@
+import type { LynxKvStore } from '../connection/types';
+import type { LynxRuntimeFetch } from '../runtime/fetch';
+import {
+  loadSessionIndexSnapshot,
+  lookupSessionIndexById,
+  pinSession,
+  unpinSession,
+} from './api';
+import { readSessionIndexStartupSnapshot, writeSessionIndexStartupSnapshot } from './cache';
+import type {
+  SessionIndexLoadResult,
+  SessionIndexLookupHit,
+  SessionIndexState,
+} from './types';
+
+export type LynxSessionIndexStore = {
+  getState: () => SessionIndexState;
+  subscribe: (listener: () => void) => () => void;
+  load: (options?: { signal?: AbortSignal }) => Promise<SessionIndexLoadResult>;
+  refresh: (options?: { signal?: AbortSignal }) => Promise<SessionIndexLoadResult>;
+  lookupById: (sessionId: string, options?: { signal?: AbortSignal }) => Promise<SessionIndexLookupHit | null>;
+  pin: (sessionId: string, options?: { signal?: AbortSignal }) => Promise<void>;
+  unpin: (sessionId: string, options?: { signal?: AbortSignal }) => Promise<void>;
+  clearForRuntimeChange: () => void;
+};
+
+export type LynxSessionIndexStoreDeps = {
+  runtimeFetch: LynxRuntimeFetch;
+  getRuntimeKey: () => string | null;
+  storage?: LynxKvStore;
+};
+
+/**
+ * Runtime-scoped session-index cache. Failed refreshes keep the previous
+ * snapshot. A runtime-key change drops in-memory state so LAN↔relay shares
+ * the cold-start cache but a different instance cannot reuse rows.
+ */
+export const createLynxSessionIndexStore = (deps: LynxSessionIndexStoreDeps): LynxSessionIndexStore => {
+  let state: SessionIndexState = {
+    status: 'idle',
+    snapshot: null,
+    error: null,
+    runtimeKey: deps.getRuntimeKey(),
+  };
+  const listeners = new Set<() => void>();
+
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+
+  const setState = (next: SessionIndexState) => {
+    state = next;
+    emit();
+  };
+
+  const applyResult = (result: SessionIndexLoadResult, runtimeKey: string | null): SessionIndexLoadResult => {
+    if (result.status === 'ok') {
+      if (runtimeKey && deps.storage) writeSessionIndexStartupSnapshot(runtimeKey, result.snapshot, deps.storage);
+      setState({ status: 'ready', snapshot: result.snapshot, error: null, runtimeKey });
+      return result;
+    }
+    if (result.status === 'unsupported') {
+      setState({ status: 'unsupported', snapshot: state.snapshot, error: null, runtimeKey });
+      return result;
+    }
+    const previous = state.snapshot;
+    setState({
+      status: 'failed',
+      snapshot: previous,
+      error: result.error,
+      runtimeKey,
+    });
+    return { ...result, previous };
+  };
+
+  const load = async (options?: { signal?: AbortSignal }): Promise<SessionIndexLoadResult> => {
+    const runtimeKey = deps.getRuntimeKey();
+    if (state.runtimeKey !== runtimeKey) {
+      const seeded = runtimeKey && deps.storage
+        ? readSessionIndexStartupSnapshot(runtimeKey, deps.storage)
+        : null;
+      setState({
+        status: seeded ? 'ready' : 'loading',
+        snapshot: seeded,
+        error: null,
+        runtimeKey,
+      });
+    } else if (state.status === 'idle') {
+      const seeded = runtimeKey && deps.storage
+        ? readSessionIndexStartupSnapshot(runtimeKey, deps.storage)
+        : null;
+      setState({
+        status: 'loading',
+        snapshot: seeded,
+        error: null,
+        runtimeKey,
+      });
+    }
+    const result = await loadSessionIndexSnapshot(deps.runtimeFetch, options);
+    return applyResult(result, runtimeKey);
+  };
+
+  return {
+    getState: () => state,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    load,
+    refresh: load,
+    lookupById: (sessionId, options) => lookupSessionIndexById(deps.runtimeFetch, sessionId, options),
+    pin: (sessionId, options) => pinSession(deps.runtimeFetch, sessionId, options),
+    unpin: (sessionId, options) => unpinSession(deps.runtimeFetch, sessionId, options),
+    clearForRuntimeChange: () => {
+      setState({ status: 'idle', snapshot: null, error: null, runtimeKey: deps.getRuntimeKey() });
+    },
+  };
+};
+
+/**
+ * Hook-shaped reader for Projects home. Lynx / ReactLynx can wrap this with
+ * `useSyncExternalStore(store.subscribe, store.getState)`.
+ */
+export const createSessionIndexHomeBindings = (store: LynxSessionIndexStore) => ({
+  subscribe: store.subscribe,
+  getSnapshot: store.getState,
+  load: store.load,
+  refresh: store.refresh,
+});

--- a/packages/lynx/src/session-index/types.ts
+++ b/packages/lynx/src/session-index/types.ts
@@ -1,0 +1,64 @@
+export type SessionIndexSession = {
+  id: string;
+  title: string;
+  directory: string;
+  parentID?: string | null;
+  hasChildren?: boolean;
+  time: {
+    created: number;
+    updated: number;
+    archived?: number;
+    pinned?: string | number | null;
+  };
+  metadata?: {
+    openchamber?: {
+      titleRefresh?: { activityUpdatedAt?: number };
+      sessionStatus?: { type?: string; changedAt?: number };
+      assistant?: { assistantID?: string; name?: string };
+    };
+  };
+};
+
+export type SessionIndexDirectory = {
+  directory: string;
+  cursor: number | null;
+  hasMore: boolean;
+  lastSyncedAt: number;
+  lastFullSyncedAt: number;
+  lastAccessedAt: number;
+  sessions: SessionIndexSession[];
+};
+
+export type SessionIndexSnapshot = {
+  revision: number;
+  sync: {
+    active: boolean;
+    completed: number;
+    total: number;
+    pendingDirectories: string[];
+    completedDirectories: string[];
+    failedDirectories: string[];
+    enriching?: boolean;
+  };
+  directories: SessionIndexDirectory[];
+  pinnedSessionIds?: string[];
+};
+
+export type SessionIndexLookupHit = {
+  id: string;
+  directory: string;
+  title?: string;
+  parentID?: string | null;
+};
+
+export type SessionIndexLoadResult =
+  | { status: 'ok'; snapshot: SessionIndexSnapshot }
+  | { status: 'unsupported' }
+  | { status: 'failed'; error: Error; previous: SessionIndexSnapshot | null };
+
+export type SessionIndexState = {
+  status: 'idle' | 'loading' | 'ready' | 'unsupported' | 'failed';
+  snapshot: SessionIndexSnapshot | null;
+  error: Error | null;
+  runtimeKey: string | null;
+};

--- a/packages/lynx/src/uuid.ts
+++ b/packages/lynx/src/uuid.ts
@@ -1,0 +1,8 @@
+export const createUuid = (): string => {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};

--- a/packages/lynx/tsconfig.json
+++ b/packages/lynx/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true,
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/lynx/vitest.config.ts
+++ b/packages/lynx/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+import { sharedExclude } from '../../vitest.shared.ts';
+
+export default defineConfig({
+  test: {
+    name: '@openchamber/lynx',
+    environment: 'node',
+    isolate: true,
+    include: ['src/**/*.test.ts'],
+    exclude: sharedExclude,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "references": [
     { "path": "./packages/ui/tsconfig.json" },
     { "path": "./packages/web/tsconfig.json" },
-    { "path": "./packages/electron/tsconfig.json" }
+    { "path": "./packages/electron/tsconfig.json" },
+    { "path": "./packages/lynx/tsconfig.json" }
   ],
   "compilerOptions": {
     "baseUrl": ".",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'packages/vscode',
       'packages/electron',
       'packages/mobile',
+      'packages/lynx',
       'packages/relay-server',
       'deploy/update-service',
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Lynx-side **connect / pairing / session-index** client on `work/lynx-native`. Does not merge `main`. No 1.18 TanStack Virtual. No pixel UI.

## What landed

`packages/lynx` (`@openchamber/lynx`) maps to Capacitor + shared UI, not invented APIs:

| Surface | Real route / contract |
|---|---|
| Pairing v2 parse / paste | `openchamber://connect?v=2&p=` — v1 rejected |
| Redeem | `POST /api/client-auth/pairing/redeem` on the first **reachable** candidate (no `/api/nearby/redeem`) |
| Probe / auto-connect / password | `GET /health`, `GET\|POST /auth/session` (`issueClientToken: true`) |
| Persistence | Full ordered LAN + relay candidate set; token in injected secure store; metadata never holds the bearer |
| Deep links | Same `openchamber://` intent union as `packages/ui/src/apps/deepLinks.ts` |
| Session index | `GET /api/openchamber/session-index` (+ lookup / pin). Failure ≠ empty. Runtime-key cache. |
| Projects home data path | `projectSessionIndexHome` + `createSessionIndexHomeBindings` (API/types, not UI) |

Connect race harness: `packages/lynx/src/connection/probe.test.ts` — **relay-only does not sleep the 1.5s LAN headstart**.

## Pitfalls

- [x] No Bonjour / Nearby browse
- [x] No invented ASR / voice product
- [x] No WebView keyboard FLIP
- [x] Official OpenCode stays on the SDK; OpenChamber uses real routes
- [x] No invented Flexoki/Finder/Capgo/Expo product
- [x] No TanStack Virtual 1.18 chat list (out of scope)
- [x] FCM / push left to another track
- [ ] 代码接上 + CI绿 + **真机过** (or explicitly not-done)

## 三关

| Gate | Status |
|---|---|
| **代码接上** | Client library wired to the Cap routes above. Host must still inject HTTP, Keychain/Keystore, and (later) the E2EE relay tunnel. |
| **CI绿** | Missing — no Lynx Android/iOS track CI yet. Local: `bunx vitest run --project @openchamber/lynx` (40 tests) + `tsc --noEmit`. |
| **真机过** | Not executed (Linux cloud VM; no Xcode / adb / physical device). |

Gap board updated: these rows are **代码接上, not landed**. Welcome UI, Instances UI, camera QR, native secure store, and Projects pixels remain missing.

## Remaining for the next slices

1. Host LynxView + inject adapters (HTTP, Keychain, optional relay tunnel).
2. Connect welcome / Instances surfaces (no demo hosts).
3. Projects home UI consuming `createSessionIndexHomeBindings`.
4. Track CI (debug APK `com.yee94.openchamber.debug` + iOS sim).
5. Device log for connect: QR or pasted v2 link → kill app → auto-reconnect → delete-active.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee57b3f1-bd92-4c6d-9ada-450285e0abe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee57b3f1-bd92-4c6d-9ada-450285e0abe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

