### PR TITLE
fix(lynx): black-screen splash + host harden + emulator smoke

### DIFF
--- a/.github/workflows/lynx-mobile-ci.yml
+++ b/.github/workflows/lynx-mobile-ci.yml
@@ -184,10 +184,51 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  android-emulator-smoke:
+    name: Android emulator smoke (Lynx template/JS)
+    runs-on: ubuntu-latest
+    needs: android-sideload-apk
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: openchamber-lynx-android-debug-apk
+          path: dist
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Emulator install + launch + logcat gate
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: bash scripts/lynx-android-emulator-smoke.sh
+
+      - name: Upload emulator logcat
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openchamber-lynx-android-emulator-logcat
+          path: emulator-smoke/
+          if-no-files-found: warn
+          retention-days: 14
+
   publish-prerelease:
     name: Prerelease sideload APK
     runs-on: ubuntu-latest
-    needs: [android-sideload-apk]
+    needs: [android-sideload-apk, android-emulator-smoke]
     if: >
       github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_prerelease != false)
@@ -221,6 +262,7 @@ jobs:
           - **label:** OpenChamber Lynx
           - **scheme:** \`openchamber-lynx://\`
           - **build:** assembleRelease + debug keystore (Expo-style; not assembleDebug)
+          - **emulator smoke:** API 30 logcat gates required green before publish
           - **bundle:** embedded \`assets/main.lynx.bundle\` (rspeedy)
           - **CI:** ${run_url}
           - **Not** 真机过 / not /releases/latest

--- a/packages/lynx/host/android/OpenChamberLynxHostActivity.kt
+++ b/packages/lynx/host/android/OpenChamberLynxHostActivity.kt
@@ -11,6 +11,9 @@ package com.yee94.openchamber.lynx
  * Sideload applicationId is `com.yee94.openchamber.lynx.debug` (unique from
  * Cap/Flutter/Expo `com.yee94.openchamber(.debug)`). See docs/lynx-pitfalls.md §6.
  *
+ * Real Activity hardens black-screen: MATCH_PARENT, preset EXACTLY measure,
+ * TemplateData/globalProps, LynxViewClient error TextView, cream windowBackground.
+ *
  * This mirror is not on the Gradle source path.
  */
 object OpenChamberLynxHostActivityMirror

--- a/packages/lynx/host/android/app/src/main/java/com/yee94/openchamber/lynx/OpenChamberLynxHostActivity.kt
+++ b/packages/lynx/host/android/app/src/main/java/com/yee94/openchamber/lynx/OpenChamberLynxHostActivity.kt
@@ -1,9 +1,20 @@
 package com.yee94.openchamber.lynx
 
-import android.app.Activity
+import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.lynx.tasm.LynxError
 import com.lynx.tasm.LynxView
 import com.lynx.tasm.LynxViewBuilder
+import com.lynx.tasm.LynxViewClient
+import com.lynx.tasm.TemplateData
 import com.lynx.xelement.XElementBehaviors
 
 /**
@@ -17,24 +28,125 @@ import com.lynx.xelement.XElementBehaviors
  * installs beside Cap/Flutter/Expo (`com.yee94.openchamber(.debug)`). FCM will
  * not work until a matching Firebase Android app is added
  * (`docs/lynx-pitfalls.md` §6). This file does not register push.
+ *
+ * Black-screen hardening:
+ * - MATCH_PARENT FrameLayout + LynxView
+ * - preset EXACTLY measure specs from DisplayMetrics (4.0 equivalent of
+ *   LynxViewSizeModeExact / preferredLayoutWidth/Height)
+ * - TemplateData init + updateGlobalProps from ViewFactory.globalProps
+ * - LynxViewClient logs + optional error TextView (never silent black)
+ * - Theme windowBackground is Flexoki cream (not black)
  */
-class OpenChamberLynxHostActivity : Activity() {
+class OpenChamberLynxHostActivity : AppCompatActivity() {
     private val decision = OpenChamberLynxEmbedding.resolve()
+    private var errorView: TextView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         check(decision.mode == LynxEmbeddingMode.A)
         check(decision.androidGlassDowngrade)
 
-        val lynxView = buildLynxView()
-        setContentView(lynxView)
-        lynxView.renderTemplateUrl(OpenChamberLynxViewFactory.BUNDLE_URL, "")
+        val root =
+            FrameLayout(this).apply {
+                layoutParams =
+                    ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+                setBackgroundColor(Color.parseColor("#fffdf4"))
+            }
+
+        val metrics = resources.displayMetrics
+        val lynxView = buildLynxView(metrics.widthPixels, metrics.heightPixels)
+        root.addView(
+            lynxView,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+
+        errorView =
+            TextView(this).apply {
+                visibility = View.GONE
+                setTextColor(Color.parseColor("#100F0F"))
+                setBackgroundColor(Color.parseColor("#fffdf4"))
+                setPadding(48, 48, 48, 48)
+                textSize = 14f
+                gravity = Gravity.CENTER
+                layoutParams =
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+            }
+        root.addView(errorView)
+
+        setContentView(root)
+
+        val globalProps = OpenChamberLynxViewFactory.globalProps(decision)
+        Log.i(TAG, "template_render_start url=${OpenChamberLynxViewFactory.BUNDLE_URL}")
+        lynxView.updateGlobalProps(globalProps)
+        lynxView.renderTemplateUrl(
+            OpenChamberLynxViewFactory.BUNDLE_URL,
+            TemplateData.fromMap(globalProps),
+        )
     }
 
-    private fun buildLynxView(): LynxView {
+    private fun buildLynxView(widthPx: Int, heightPx: Int): LynxView {
+        val widthSpec = View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY)
+        val heightSpec = View.MeasureSpec.makeMeasureSpec(heightPx, View.MeasureSpec.EXACTLY)
+
         val viewBuilder = LynxViewBuilder()
         viewBuilder.addBehaviors(XElementBehaviors().create())
         viewBuilder.setTemplateProvider(OpenChamberLynxTemplateProvider(this))
-        return viewBuilder.build(this)
+        // 4.0 Android equivalent of preferredLayout + LynxViewSizeModeExact.
+        viewBuilder.setScreenSize(widthPx, heightPx)
+        viewBuilder.setPresetMeasuredSpec(widthSpec, heightSpec)
+
+        val lynxView = viewBuilder.build(this)
+        lynxView.addLynxViewClient(
+            object : LynxViewClient() {
+                override fun onPageStart(url: String?) {
+                    Log.i(TAG, "template_page_start url=$url")
+                }
+
+                override fun onLoadSuccess() {
+                    Log.i(TAG, "template_load_success")
+                }
+
+                override fun onFirstScreen() {
+                    Log.i(TAG, "first_screen")
+                }
+
+                override fun onLoadFailed(message: String?) {
+                    showHostError("Lynx load failed: ${message ?: "unknown"}")
+                }
+
+                override fun onReceivedError(error: LynxError?) {
+                    showHostError("Lynx error: ${error?.msg ?: error?.toString() ?: "unknown"}")
+                }
+
+                override fun onReceivedJSError(jsError: LynxError?) {
+                    showHostError("Lynx JS error: ${jsError?.msg ?: jsError?.toString() ?: "unknown"}")
+                }
+            },
+        )
+        return lynxView
+    }
+
+    private fun showHostError(message: String) {
+        Log.e(TAG, message)
+        runOnUiThread {
+            errorView?.let { tv ->
+                tv.text = message
+                tv.visibility = View.VISIBLE
+                tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "OpenChamberLynx"
     }
 }

--- a/packages/lynx/host/android/app/src/main/java/com/yee94/openchamber/lynx/OpenChamberLynxTemplateProvider.kt
+++ b/packages/lynx/host/android/app/src/main/java/com/yee94/openchamber/lynx/OpenChamberLynxTemplateProvider.kt
@@ -1,6 +1,7 @@
 package com.yee94.openchamber.lynx
 
 import android.content.Context
+import android.util.Log
 import com.lynx.tasm.provider.AbsTemplateProvider
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -23,11 +24,19 @@ class OpenChamberLynxTemplateProvider(
                     while (input.read(buffer).also { length = it } != -1) {
                         out.write(buffer, 0, length)
                     }
-                    callback.onSuccess(out.toByteArray())
+                    val bytes = out.toByteArray()
+                    Log.i(TAG, "assets_open_ok uri=$uri bytes=${bytes.size}")
+                    callback.onSuccess(bytes)
                 }
             } catch (e: IOException) {
-                callback.onFailed(e.message ?: "failed to load template: $uri")
+                val msg = e.message ?: "failed to load template: $uri"
+                Log.e(TAG, "assets_open_failure uri=$uri err=$msg", e)
+                callback.onFailed(msg)
             }
         }.start()
+    }
+
+    companion object {
+        private const val TAG = "OpenChamberLynx"
     }
 }

--- a/packages/lynx/host/android/app/src/main/res/values/colors.xml
+++ b/packages/lynx/host/android/app/src/main/res/values/colors.xml
@@ -2,4 +2,7 @@
 <resources>
     <color name="ic_launcher_background">#111111</color>
     <color name="ic_launcher_foreground">#F5F5F5</color>
+    <!-- Flexoki-light cream — failures must not paint as a pure black void. -->
+    <color name="lynx_window_background">#fffdf4</color>
+    <color name="lynx_error_text">#100F0F</color>
 </resources>

--- a/packages/lynx/host/android/app/src/main/res/values/themes.xml
+++ b/packages/lynx/host/android/app/src/main/res/values/themes.xml
@@ -2,7 +2,8 @@
 <resources>
     <style name="Theme.OpenChamberLynx" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/black</item>
-        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:navigationBarColor">@color/lynx_window_background</item>
+        <item name="android:windowBackground">@color/lynx_window_background</item>
+        <item name="android:colorBackground">@color/lynx_window_background</item>
     </style>
 </resources>

--- a/packages/lynx/src/App.tsx
+++ b/packages/lynx/src/App.tsx
@@ -28,6 +28,26 @@ export type AppProps = {
   lynxClientVersion?: string;
 };
 
+
+function readLynxGlobalProps(): Partial<LynxHostGlobalProps> | undefined {
+  try {
+    const gp = (globalThis as { lynx?: { __globalProps?: Partial<LynxHostGlobalProps> } }).lynx
+      ?.__globalProps;
+    return gp && typeof gp === 'object' ? gp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveHostFromGlobalProps(): LynxHostGlobalProps {
+  const gp = readLynxGlobalProps();
+  return createHostGlobalProps({
+    platform: gp?.platform === 'ios' ? 'ios' : 'android',
+    themeId: gp?.themeId,
+    locale: gp?.locale,
+  });
+}
+
 /**
  * Full-page Lynx entry. Hosts that own Tab/Nav (Mode B) pass
  * `chromeOwner: 'host'` so this tree does not paint a second dock.
@@ -39,7 +59,7 @@ export function App({
   skipAutoConnect = false,
   lynxClientVersion = '1.19.7-beta.7',
 }: AppProps) {
-  const resolved = host ?? createHostGlobalProps({ platform: 'android' });
+  const resolved = host ?? resolveHostFromGlobalProps();
 
   const client = useMemo(() => {
     if (injectedClient) return injectedClient;

--- a/packages/lynx/src/connect/ConnectWelcome.tsx
+++ b/packages/lynx/src/connect/ConnectWelcome.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { LynxConnectionClient } from '../connection/client';
 import type { LynxPendingConnection, LynxSavedConnection } from '../connection/types';
 import { connectionDisplayUrl } from '../connection/urls';
 import { lynxT } from '../i18n/catalog';
 import { LynxScrollView, LynxText, LynxView } from '../lynx-elements';
-import { cssVar } from '../theme/tokens';
+import { LYNX_LIGHT_FALLBACKS, cssVar } from '../theme/tokens';
 import type { LynxAutoConnectPhase } from './autoConnectPhase';
 import type { LynxCameraAdapter } from '../host/camera';
 import { parsePastedPairingLink } from './pairingPaste';
@@ -50,23 +50,39 @@ export function ConnectWelcome({
   const [addLabel, setAddLabel] = useState('');
   const [addUrl, setAddUrl] = useState('');
 
+  // First-paint must never depend solely on unresolved Cap CSS vars — cream + dark
+  // text stay visible even when the host has not injected theme styles.
+  const splashBg = LYNX_LIGHT_FALLBACKS['surface.background'];
+  const splashFg = LYNX_LIGHT_FALLBACKS['surface.foreground'];
+  const splashMuted = LYNX_LIGHT_FALLBACKS['surface.mutedForeground'];
+
+  useEffect(() => {
+    if (phase === 'done') return;
+    // Emulator smoke greps this line (logcat / Lynx console) as proof splash mounted.
+    console.log('[OpenChamberLynx] ConnectWelcome splash');
+  }, [phase]);
+
+
   if (phase !== 'done') {
     return (
       <LynxView
         style={{
           flexGrow: 1,
+          width: '100%',
+          minHeight: '100%',
           alignItems: 'center',
           justifyContent: 'center',
           padding: '24px',
-          backgroundColor: cssVar('surface.background'),
+          // Hardcoded Flexoki-light cream — never transparent on black windowBackground.
+          backgroundColor: splashBg,
         }}
         accessibility-label={lynxT(locale, 'lynx.connect.splash')}
       >
-        <LynxText style={{ color: cssVar('surface.foreground'), fontSize: '20px', fontWeight: '600' }}>
+        <LynxText style={{ color: splashFg, fontSize: '20px', fontWeight: '600' }}>
           {lynxT(locale, 'lynx.connect.splash')}
         </LynxText>
         {autoConnectLabel ? (
-          <LynxText style={{ color: cssVar('surface.mutedForeground'), marginTop: '8px' }}>
+          <LynxText style={{ color: splashMuted, marginTop: '8px' }}>
             {autoConnectLabel}
           </LynxText>
         ) : null}
@@ -199,7 +215,7 @@ export function ConnectWelcome({
       style={{
         flexGrow: 1,
         padding: '24px 16px',
-        backgroundColor: cssVar('surface.background'),
+        backgroundColor: cssVar('surface.background'), // var(--surface-background, #fffdf4)
       }}
     >
       <LynxText

--- a/packages/lynx/src/host/native-sources.test.ts
+++ b/packages/lynx/src/host/native-sources.test.ts
@@ -35,7 +35,20 @@ describe('native host sources', () => {
     expect(activity).toContain('Do not add a fifth Chat destination');
     expect(activity).toContain('com.yee94.openchamber.lynx.debug');
     expect(activity).toContain('renderTemplateUrl');
+    expect(activity).toContain('AppCompatActivity');
+    expect(activity).toContain('MATCH_PARENT');
+    expect(activity).toContain('setPresetMeasuredSpec');
+    expect(activity).toContain('updateGlobalProps');
+    expect(activity).toContain('TemplateData.fromMap');
+    expect(activity).toContain('addLynxViewClient');
+    expect(activity).toContain('OpenChamberLynx');
     expect(app).toContain('LynxEnv.inst()');
+    const themes = await readFile(
+      join(hostRoot, 'android/app/src/main/res/values/themes.xml'),
+      'utf8',
+    );
+    expect(themes).toContain('lynx_window_background');
+    expect(themes).not.toContain('@android:color/black');
   });
 
   test('host scaffold includes deepened bridge protocols', async () => {

--- a/packages/lynx/src/theme/tokens.test.ts
+++ b/packages/lynx/src/theme/tokens.test.ts
@@ -1,26 +1,38 @@
 import { describe, expect, test } from 'vitest';
 
-import { LYNX_TOKEN_CSS_VARS, cssVar, type LynxSemanticToken } from './tokens';
+import {
+  LYNX_LIGHT_FALLBACKS,
+  LYNX_TOKEN_CSS_VARS,
+  cssVar,
+  type LynxSemanticToken,
+} from './tokens';
 
 describe('Lynx semantic tokens', () => {
   test('exposes Cap status success/error for portable diff add/del', () => {
     expect(LYNX_TOKEN_CSS_VARS['status.success']).toBe('--status-success');
     expect(LYNX_TOKEN_CSS_VARS['status.error']).toBe('--status-error');
-    expect(cssVar('status.success')).toBe('var(--status-success)');
-    expect(cssVar('status.error')).toBe('var(--status-error)');
+    expect(cssVar('status.success')).toBe('var(--status-success, #66800B)');
+    expect(cssVar('status.error')).toBe('var(--status-error, #AF3029)');
   });
 
   test('exposes Cap on-error (destructive-foreground) for solid error fills', () => {
     expect(LYNX_TOKEN_CSS_VARS['status.onError']).toBe('--destructive-foreground');
-    expect(cssVar('status.onError')).toBe('var(--destructive-foreground)');
+    expect(cssVar('status.onError')).toBe('var(--destructive-foreground, #fffdf4)');
   });
 
-  test('every semantic token maps to a Cap CSS var', () => {
+  test('every semantic token maps to a Cap CSS var with Flexoki-light fallback', () => {
     const keys = Object.keys(LYNX_TOKEN_CSS_VARS) as LynxSemanticToken[];
     expect(keys.length).toBeGreaterThanOrEqual(11);
     for (const key of keys) {
       expect(LYNX_TOKEN_CSS_VARS[key].startsWith('--')).toBe(true);
-      expect(cssVar(key)).toBe(`var(${LYNX_TOKEN_CSS_VARS[key]})`);
+      expect(LYNX_LIGHT_FALLBACKS[key]).toMatch(/^#/);
+      expect(cssVar(key)).toBe(`var(${LYNX_TOKEN_CSS_VARS[key]}, ${LYNX_LIGHT_FALLBACKS[key]})`);
+      expect(cssVar(key, null)).toBe(`var(${LYNX_TOKEN_CSS_VARS[key]})`);
     }
+  });
+
+  test('surface first-paint fallbacks are Flexoki-light cream + dark ink', () => {
+    expect(LYNX_LIGHT_FALLBACKS['surface.background']).toBe('#fffdf4');
+    expect(LYNX_LIGHT_FALLBACKS['surface.foreground']).toBe('#100F0F');
   });
 });

--- a/packages/lynx/src/theme/tokens.ts
+++ b/packages/lynx/src/theme/tokens.ts
@@ -51,6 +51,32 @@ export function themeVariantForId(themeId: LynxThemeId): 'light' | 'dark' {
   return themeId === LYNX_DEFAULT_THEME_IDS.dark ? 'dark' : 'light';
 }
 
-export function cssVar(token: LynxSemanticToken): string {
-  return `var(${LYNX_TOKEN_CSS_VARS[token]})`;
+/**
+ * Flexoki-light hex fallbacks for first paint when Cap CSS vars are not injected
+ * into the Lynx page (native sideload). Prefer `cssVar(token)` which embeds these
+ * as `var(--name, fallback)` so unresolved vars never go transparent/invisible.
+ */
+export const LYNX_LIGHT_FALLBACKS: Record<LynxSemanticToken, string> = {
+  'surface.background': '#fffdf4',
+  'surface.foreground': '#100F0F',
+  'surface.muted': '#f6f5ee',
+  'surface.mutedForeground': '#686663',
+  'surface.elevated': '#fbfaf2',
+  'interactive.selection': '#76736f30',
+  'interactive.selectionForeground': '#100F0F',
+  'primary.base': '#BC5215',
+  'primary.foreground': '#fffdf4',
+  'status.success': '#66800B',
+  'status.error': '#AF3029',
+  'status.onError': '#fffdf4',
+};
+
+/**
+ * CSS var with Flexoki-light fallback. Pass `fallback: null` to emit bare
+ * `var(--name)` (tests / callers that intentionally omit fallbacks).
+ */
+export function cssVar(token: LynxSemanticToken, fallback: string | null = LYNX_LIGHT_FALLBACKS[token]): string {
+  const name = LYNX_TOKEN_CSS_VARS[token];
+  if (fallback == null) return `var(${name})`;
+  return `var(${name}, ${fallback})`;
 }

--- a/scripts/lynx-android-emulator-smoke.sh
+++ b/scripts/lynx-android-emulator-smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Emulator smoke: install Lynx sideload APK, launch HostActivity, require template
+# load / JS splash evidence AND stay alive (no FATAL / JS crash / assets open failure).
+# Mirrors scripts/expo-android-emulator-smoke.sh (logcat gates only — no screencap).
+set -euo pipefail
+
+APK=$(ls dist/*.apk | head -n 1)
+test -f "$APK"
+PKG=com.yee94.openchamber.lynx.debug
+ACTIVITY=com.yee94.openchamber.lynx.OpenChamberLynxHostActivity
+mkdir -p emulator-smoke
+
+adb wait-for-device
+adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 2; done'
+
+adb uninstall "$PKG" >/dev/null 2>&1 || true
+adb logcat -c
+adb install -r -g "$APK"
+
+adb logcat -v threadtime > emulator-smoke/logcat-full.txt &
+LOGCAT_PID=$!
+
+adb shell am start -W -n "$PKG/$ACTIVITY" | tee emulator-smoke/am-start.txt
+
+SAW_LYNX=0
+for i in $(seq 1 60); do
+  sleep 2
+  adb logcat -d -v brief > emulator-smoke/logcat-snapshot.txt || true
+
+  if grep -Eiq 'assets_open_failure|failed to load template|Unable to open asset|FileNotFoundException.*main\.lynx\.bundle' emulator-smoke/logcat-snapshot.txt; then
+    echo "::error::assets / template open failure in logcat"
+    grep -Ei 'assets_open_failure|failed to load template|main\.lynx\.bundle|FileNotFoundException' emulator-smoke/logcat-snapshot.txt | tail -40 || true
+    kill "$LOGCAT_PID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  if grep -Eq "Process: ${PKG}" emulator-smoke/logcat-snapshot.txt && grep -Eq 'FATAL EXCEPTION|JavascriptException' emulator-smoke/logcat-snapshot.txt; then
+    echo "::error::FATAL / JavascriptException for $PKG"
+    grep -E "OpenChamberLynx|LynxView|FATAL EXCEPTION|JavascriptException|AndroidRuntime" emulator-smoke/logcat-snapshot.txt | tail -60 || true
+    kill "$LOGCAT_PID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  # Proof Lynx/JS entered (Expo equivalent of ReactNativeJS Running "main"):
+  # host template_load_success / first_screen, or splash console line, or LynxView render.
+  if grep -Eq 'OpenChamberLynx.*(template_load_success|first_screen|ConnectWelcome splash)' emulator-smoke/logcat-snapshot.txt \
+    || grep -Fq '[OpenChamberLynx] ConnectWelcome splash' emulator-smoke/logcat-snapshot.txt \
+    || grep -Eiq 'LynxView.*renderTemplateUrl.*main\.lynx\.bundle' emulator-smoke/logcat-snapshot.txt; then
+    SAW_LYNX=1
+  fi
+
+  if ! adb shell pidof "$PKG" >/dev/null 2>&1; then
+    sleep 2
+    if ! adb shell pidof "$PKG" >/dev/null 2>&1; then
+      echo "::error::App process $PKG not running after launch (crashed?)"
+      kill "$LOGCAT_PID" >/dev/null 2>&1 || true
+      exit 1
+    fi
+  fi
+
+  # After Lynx/JS evidence, dwell ~10s more and require process still alive.
+  if [ "$SAW_LYNX" = "1" ] && [ "$i" -ge 8 ]; then
+    if adb shell pidof "$PKG" >/dev/null 2>&1; then
+      echo "OK: Lynx template/JS evidence + process alive at attempt $i"
+      break
+    fi
+  fi
+done
+
+sleep 3
+kill "$LOGCAT_PID" >/dev/null 2>&1 || true
+wait "$LOGCAT_PID" 2>/dev/null || true
+adb logcat -d -v threadtime > emulator-smoke/logcat-full.txt || true
+
+{
+  echo "=== am start ==="
+  cat emulator-smoke/am-start.txt || true
+  echo ""
+  echo "=== pidof ==="
+  adb shell pidof "$PKG" || echo "(no pid)"
+  echo ""
+  echo "=== filtered (OpenChamberLynx / LynxView / AndroidRuntime) ==="
+  grep -E "OpenChamberLynx|LynxView|AndroidRuntime|JavascriptException|FATAL EXCEPTION|main\.lynx\.bundle|ConnectWelcome" emulator-smoke/logcat-full.txt || echo "(no matches)"
+} | tee emulator-smoke/logcat-evidence.txt
+
+if [ "$SAW_LYNX" != "1" ]; then
+  echo "::error::Timed out without Lynx template/JS evidence — black screen / failed load?"
+  exit 1
+fi
+
+if ! adb shell pidof "$PKG" >/dev/null 2>&1; then
+  echo "::error::Process dead at end of smoke — crash after launch"
+  exit 1
+fi
+
+if grep -Eq "Process: ${PKG}" emulator-smoke/logcat-full.txt && grep -Eq 'FATAL EXCEPTION|JavascriptException' emulator-smoke/logcat-full.txt; then
+  echo "::error::FATAL / JavascriptException present in full logcat"
+  exit 1
+fi
+
+if grep -Eiq 'assets_open_failure|failed to load template' emulator-smoke/logcat-full.txt; then
+  echo "::error::assets open failure present in full logcat"
+  exit 1
+fi
+
+echo "PASS: emulator smoke past Lynx template load and process stable"


### PR DESCRIPTION
## Summary
- **Root cause (verified):** ConnectWelcome splash used `cssVar('surface.*')` with no fallback while Theme `windowBackground` was `@android:color/black`. Unresolved Cap CSS vars → transparent bg + invisible text on black window = empty black void. Host also never passed `ViewFactory.globalProps`, used bare `setContentView(LynxView)` without MATCH_PARENT / preset EXACTLY measure, and had no LynxViewClient error surface.
- Hardcoded Flexoki-light cream (`#fffdf4`) + dark ink (`#100F0F`) for splash first paint; `cssVar()` now embeds light fallbacks.
- HostActivity → AppCompatActivity + FrameLayout MATCH_PARENT + `setPresetMeasuredSpec(EXACTLY)` + `updateGlobalProps`/`TemplateData.fromMap` + LynxViewClient Log.e + error TextView; cream windowBackground.
- Add `scripts/lynx-android-emulator-smoke.sh` (Expo mirror: adb install → am start → logcat gates; **no screencap**). Wire API 30 smoke into `lynx-mobile-ci.yml`; **publish-prerelease needs smoke green**.

## Test plan
- [x] `bun run --cwd packages/lynx test` (tokens + native-sources)
- [x] `bun run --cwd packages/lynx type-check`
- [ ] CI: lynx-linux + android-sideload-apk + android-emulator-smoke green
- [ ] New prerelease `lynx-v2-debug-<sha7>` APK shows Connecting… on cream, not black void