### PR TITLE
fix(lynx): TextDecoder polyfill so splash mounts

### DIFF
--- a/packages/lynx/src/chat/liveTail.ts
+++ b/packages/lynx/src/chat/liveTail.ts
@@ -180,12 +180,16 @@ export function applyNormalizedEventToTimeline(
   return { state: applyLynxLivePatch(state, patch), patch };
 }
 
-const decoder = new TextDecoder();
+function createUtf8StreamDecoder(): TextDecoder {
+  // Lazily construct — PrimJS may lack TextDecoder until encoding-polyfill runs.
+  return new TextDecoder();
+}
 
 async function* readUtf8Chunks(
   stream: ReadableStream<Uint8Array>,
   signal: AbortSignal,
 ): AsyncIterable<string> {
+  const decoder = createUtf8StreamDecoder();
   const reader = stream.getReader();
   try {
     while (!signal.aborted) {

--- a/packages/lynx/src/encoding-polyfill.test.ts
+++ b/packages/lynx/src/encoding-polyfill.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('encoding-polyfill', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    const g = globalThis as typeof globalThis & {
+      TextEncoder?: unknown;
+      TextDecoder?: unknown;
+    };
+    // Force reinstall path — cast through unknown for delete under DOM lib types.
+    Reflect.deleteProperty(g, 'TextEncoder');
+    Reflect.deleteProperty(g, 'TextDecoder');
+  });
+
+  test('installs TextEncoder/TextDecoder when missing', async () => {
+    await import('./encoding-polyfill');
+    expect(typeof TextEncoder).toBe('function');
+    expect(typeof TextDecoder).toBe('function');
+    const encoded = new TextEncoder().encode('Connecting…');
+    expect(encoded.byteLength).toBeGreaterThan(0);
+    expect(new TextDecoder().decode(encoded)).toBe('Connecting…');
+  });
+});

--- a/packages/lynx/src/encoding-polyfill.ts
+++ b/packages/lynx/src/encoding-polyfill.ts
@@ -1,0 +1,79 @@
+/**
+ * PrimJS / Lynx sideload does not ship TextEncoder / TextDecoder.
+ * Install before any module that constructs them at import time
+ * (e.g. chat/liveTail), otherwise loadCard fails with ReferenceError and
+ * ConnectWelcome never mounts.
+ */
+
+function installEncodingPolyfill(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+
+  if (typeof g.TextEncoder === 'undefined') {
+    g.TextEncoder = class TextEncoder {
+      encode(input = ''): Uint8Array {
+        const utf8 = unescape(encodeURIComponent(input));
+        const out = new Uint8Array(utf8.length);
+        for (let i = 0; i < utf8.length; i += 1) out[i] = utf8.charCodeAt(i);
+        return out;
+      }
+      encodeInto(input: string, dest: Uint8Array): { read: number; written: number } {
+        const encoded = this.encode(input);
+        const written = Math.min(encoded.length, dest.length);
+        dest.set(encoded.subarray(0, written));
+        return { read: input.length, written };
+      }
+      get encoding(): string {
+        return 'utf-8';
+      }
+    };
+  }
+
+  if (typeof g.TextDecoder === 'undefined') {
+    g.TextDecoder = class TextDecoder {
+      readonly encoding = 'utf-8';
+      readonly fatal = false;
+      readonly ignoreBOM = false;
+      private pending = '';
+
+      constructor(_label?: string, _options?: TextDecoderOptions) {}
+
+      decode(input?: BufferSource, options?: TextDecodeOptions): string {
+        if (input == null) {
+          const tail = this.pending;
+          this.pending = '';
+          return tail;
+        }
+        const bytes =
+          input instanceof ArrayBuffer
+            ? new Uint8Array(input)
+            : input instanceof Uint8Array
+              ? input
+              : new Uint8Array((input as ArrayBufferView).buffer);
+        let binary = this.pending;
+        this.pending = '';
+        for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i]!);
+        // Incomplete trailing multi-byte sequences are rare for our SSE use; keep simple.
+        try {
+          const decoded = decodeURIComponent(escape(binary));
+          if (options?.stream) return decoded;
+          return decoded;
+        } catch {
+          if (options?.stream) {
+            this.pending = binary.slice(-3);
+            try {
+              return decodeURIComponent(escape(binary.slice(0, -this.pending.length)));
+            } catch {
+              return binary;
+            }
+          }
+          return binary;
+        }
+      }
+    };
+  }
+}
+
+installEncodingPolyfill();
+
+export {};

--- a/packages/lynx/src/index.tsx
+++ b/packages/lynx/src/index.tsx
@@ -1,8 +1,13 @@
+import './encoding-polyfill';
+
 import { App } from './App';
 
 /**
  * Rspeedy / Lynx Explorer entry. The host LynxView loads the compiled bundle
  * and injects `global-props` for embedding mode, locale, and theme id.
+ *
+ * encoding-polyfill runs before App (and its ShellApp/chat import graph) so
+ * PrimJS gets TextEncoder/TextDecoder before liveTail top-level init.
  */
 export default App;
 

--- a/scripts/lynx-android-emulator-smoke.sh
+++ b/scripts/lynx-android-emulator-smoke.sh
@@ -34,6 +34,20 @@ for i in $(seq 1 60); do
     exit 1
   fi
 
+  # JS must actually run — template_load_success alone is not enough (TextDecoder crash).
+  if grep -Eiq 'TextDecoder is not defined|TextEncoder is not defined|loadCard failed' emulator-smoke/logcat-snapshot.txt; then
+    echo "::error::Lynx JS runtime failure (encoding / loadCard) — splash never mounts"
+    grep -Ei 'TextDecoder|TextEncoder|loadCard failed|OpenChamberLynx: Lynx' emulator-smoke/logcat-snapshot.txt | tail -40 || true
+    kill "$LOGCAT_PID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+  if grep -Fq 'OpenChamberLynx: Lynx JS error' emulator-smoke/logcat-snapshot.txt; then
+    echo "::error::OpenChamberLynx Lynx JS error in logcat"
+    grep -F 'OpenChamberLynx: Lynx JS error' emulator-smoke/logcat-snapshot.txt | tail -20 || true
+    kill "$LOGCAT_PID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
   if grep -Eq "Process: ${PKG}" emulator-smoke/logcat-snapshot.txt && grep -Eq 'FATAL EXCEPTION|JavascriptException' emulator-smoke/logcat-snapshot.txt; then
     echo "::error::FATAL / JavascriptException for $PKG"
     grep -E "OpenChamberLynx|LynxView|FATAL EXCEPTION|JavascriptException|AndroidRuntime" emulator-smoke/logcat-snapshot.txt | tail -60 || true
@@ -43,9 +57,10 @@ for i in $(seq 1 60); do
 
   # Proof Lynx/JS entered (Expo equivalent of ReactNativeJS Running "main"):
   # host template_load_success / first_screen, or splash console line, or LynxView render.
-  if grep -Eq 'OpenChamberLynx.*(template_load_success|first_screen|ConnectWelcome splash)' emulator-smoke/logcat-snapshot.txt \
-    || grep -Fq '[OpenChamberLynx] ConnectWelcome splash' emulator-smoke/logcat-snapshot.txt \
-    || grep -Eiq 'LynxView.*renderTemplateUrl.*main\.lynx\.bundle' emulator-smoke/logcat-snapshot.txt; then
+  # Prefer JS splash log (proof ConnectWelcome mounted). Fall back to template_load_success
+  # only after JS-error gates above have passed.
+  if grep -Fq '[OpenChamberLynx] ConnectWelcome splash' emulator-smoke/logcat-snapshot.txt \
+    || grep -Eq 'OpenChamberLynx.*(ConnectWelcome splash|template_load_success|first_screen)' emulator-smoke/logcat-snapshot.txt; then
     SAW_LYNX=1
   fi
 
@@ -100,6 +115,16 @@ fi
 
 if grep -Eiq 'assets_open_failure|failed to load template' emulator-smoke/logcat-full.txt; then
   echo "::error::assets open failure present in full logcat"
+  exit 1
+fi
+
+if grep -Eiq 'TextDecoder is not defined|TextEncoder is not defined|loadCard failed' emulator-smoke/logcat-full.txt; then
+  echo "::error::Lynx JS encoding/loadCard failure present in full logcat"
+  exit 1
+fi
+
+if grep -Fq 'OpenChamberLynx: Lynx JS error' emulator-smoke/logcat-full.txt; then
+  echo "::error::OpenChamberLynx Lynx JS error present in full logcat"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- CI smoke on `c04a7fb` showed `template_load_success` **then** `ReferenceError: TextDecoder is not defined` / `loadCard failed` — ConnectWelcome never mounted (error TextView on cream).
- Add `encoding-polyfill` as the **first** `index.tsx` import; lazy-construct decoder in `liveTail`.
- Tighten `lynx-android-emulator-smoke.sh` to **fail** on TextDecoder/loadCard / `Lynx JS error` (not only FATAL).

## Test plan
- [x] type-check + vitest (polyfill + liveTail)
- [ ] CI emulator smoke green with ConnectWelcome splash log
- [ ] New `lynx-v2-debug-<sha>` APK shows Connecting… text