### PR TITLE
fix(lynx): root page + hard splash to fix cream void white screen

### DIFF
--- a/packages/lynx/host/android/app/src/main/java/com/yee94/openchamber/lynx/OpenChamberLynxHostActivity.kt
+++ b/packages/lynx/host/android/app/src/main/java/com/yee94/openchamber/lynx/OpenChamberLynxHostActivity.kt
@@ -117,6 +117,17 @@ class OpenChamberLynxHostActivity : AppCompatActivity() {
 
                 override fun onFirstScreen() {
                     Log.i(TAG, "first_screen")
+                    // Force a second layout pass — some hosts paint cream void until requestLayout.
+                    lynxView.post {
+                        lynxView.requestLayout()
+                        lynxView.invalidate()
+                        val w = lynxView.width
+                        val h = lynxView.height
+                        Log.i(TAG, "first_screen_measured width=$w height=$h")
+                        if (w <= 0 || h <= 0) {
+                            showHostError("LynxView measured ${w}x${h} after first_screen (expected non-zero)")
+                        }
+                    }
                 }
 
                 override fun onLoadFailed(message: String?) {

--- a/packages/lynx/src/App.tsx
+++ b/packages/lynx/src/App.tsx
@@ -16,8 +16,17 @@ import {
   type LynxAutoConnectPhase,
 } from './connect/autoConnectPhase';
 import { createHostGlobalProps, type LynxHostGlobalProps } from './host/embedding';
+import { LynxPage } from './lynx-elements';
 import { createSessionIndexHomeBindings, createLynxSessionIndexStore } from './session-index/store';
 import { LynxShellApp } from './shell/ShellApp';
+
+/** Root `<page>` styles — Lynx first-screen without page often paints blank cream. */
+const ROOT_PAGE_STYLE = {
+  width: '100%',
+  height: '100%',
+  flexGrow: 1,
+  backgroundColor: '#fffdf4',
+} as const;
 
 export type AppProps = {
   host?: LynxHostGlobalProps;
@@ -114,32 +123,36 @@ export function App({
 
   if (gate.kind === 'splash' || gate.kind === 'welcome') {
     return (
-      <ConnectWelcome
-        locale={resolved.locale}
-        phase={phase}
-        autoConnectLabel={autoConnectLabel}
-        client={client}
-        connections={connections}
-        pending={pending}
-        error={error}
-        onConnected={() => setConnected(true)}
-        onConnectionsChange={setConnections}
-        onPendingChange={setPending}
-        onError={setError}
-      />
+      <LynxPage style={ROOT_PAGE_STYLE} accessibility-label="OpenChamber Lynx">
+        <ConnectWelcome
+          locale={resolved.locale}
+          phase={phase}
+          autoConnectLabel={autoConnectLabel}
+          client={client}
+          connections={connections}
+          pending={pending}
+          error={error}
+          onConnected={() => setConnected(true)}
+          onConnectionsChange={setConnections}
+          onPendingChange={setPending}
+          onError={setError}
+        />
+      </LynxPage>
     );
   }
 
   return (
-    <LynxShellApp
-      host={resolved}
-      runtimeFetch={client.runtimeFetch}
-      sessionIndexBindings={sessionIndexBindings}
-      connectionClient={client}
-      connections={connections}
-      onConnectionsChange={setConnections}
-      onConnected={() => setConnected(true)}
-      lynxClientVersion={lynxClientVersion}
-    />
+    <LynxPage style={ROOT_PAGE_STYLE} auto-height accessibility-label="OpenChamber Lynx">
+      <LynxShellApp
+        host={resolved}
+        runtimeFetch={client.runtimeFetch}
+        sessionIndexBindings={sessionIndexBindings}
+        connectionClient={client}
+        connections={connections}
+        onConnectionsChange={setConnections}
+        onConnected={() => setConnected(true)}
+        lynxClientVersion={lynxClientVersion}
+      />
+    </LynxPage>
   );
 }

--- a/packages/lynx/src/connect/ConnectWelcome.tsx
+++ b/packages/lynx/src/connect/ConnectWelcome.tsx
@@ -64,11 +64,14 @@ export function ConnectWelcome({
 
 
   if (phase !== 'done') {
+    // Hard literals first so a blank cream screen is impossible even if i18n fails.
+    // Root <page> is provided by App — keep splash as a full-size <view>.
     return (
       <LynxView
         style={{
           flexGrow: 1,
           width: '100%',
+          height: '100%',
           minHeight: '100%',
           alignItems: 'center',
           justifyContent: 'center',
@@ -76,9 +79,15 @@ export function ConnectWelcome({
           // Hardcoded Flexoki-light cream — never transparent on black windowBackground.
           backgroundColor: splashBg,
         }}
-        accessibility-label={lynxT(locale, 'lynx.connect.splash')}
+        accessibility-label="OpenChamber Lynx"
       >
-        <LynxText style={{ color: splashFg, fontSize: '20px', fontWeight: '600' }}>
+        <LynxText style={{ color: splashFg, fontSize: '22px', fontWeight: '700' }}>
+          OpenChamber Lynx
+        </LynxText>
+        <LynxText style={{ color: splashFg, fontSize: '18px', fontWeight: '600', marginTop: '12px' }}>
+          Connecting…
+        </LynxText>
+        <LynxText style={{ color: splashMuted, fontSize: '14px', marginTop: '8px' }}>
           {lynxT(locale, 'lynx.connect.splash')}
         </LynxText>
         {autoConnectLabel ? (
@@ -214,9 +223,12 @@ export function ConnectWelcome({
     <LynxScrollView
       style={{
         flexGrow: 1,
+        width: '100%',
+        height: '100%',
         padding: '24px 16px',
         backgroundColor: cssVar('surface.background'), // var(--surface-background, #fffdf4)
       }}
+      accessibility-label="OpenChamber Lynx"
     >
       <LynxText
         style={{

--- a/packages/lynx/src/index.tsx
+++ b/packages/lynx/src/index.tsx
@@ -1,14 +1,22 @@
 import './encoding-polyfill';
 
+import { root } from '@lynx-js/react';
+
 import { App } from './App';
 
 /**
- * Rspeedy / Lynx Explorer entry. The host LynxView loads the compiled bundle
- * and injects `global-props` for embedding mode, locale, and theme id.
+ * Rspeedy / Lynx Explorer entry. ReactLynx requires an explicit `root.render`
+ * (export default alone does not mount the tree on device). Host LynxView
+ * loads the compiled bundle and injects `global-props` for embedding mode,
+ * locale, and theme id.
  *
  * encoding-polyfill runs before App (and its ShellApp/chat import graph) so
  * PrimJS gets TextEncoder/TextDecoder before liveTail top-level init.
+ *
+ * Keep named/default App exports for package consumers and Explorer tooling;
+ * only this side-effect mounts the card.
  */
-export default App;
+root.render(<App />);
 
-export { App } from './App';
+export { App };
+export default App;

--- a/packages/lynx/src/shell/ShellApp.tsx
+++ b/packages/lynx/src/shell/ShellApp.tsx
@@ -14,7 +14,7 @@ import {
 import { isLynxMobileSettingsSlug, type LynxMobileSettingsSlug } from '../settings/slugs';
 import { shouldPaintLynxDock, type LynxHostGlobalProps } from '../host/embedding';
 import { lynxT } from '../i18n/catalog';
-import { LynxPage, LynxText, LynxView } from '../lynx-elements';
+import { LynxText, LynxView } from '../lynx-elements';
 import type { LynxRuntimeFetch } from '../runtime/fetch';
 import type { LynxConnectionClient } from '../connection/client';
 import type { LynxSavedConnection } from '../connection/types';
@@ -313,11 +313,13 @@ export function LynxShellApp({
     ?? null;
   const showDetachedSheet = Boolean(chatSheet) && !chatRoute && !assistantRoute?.sessionId;
 
+  // Outer root <page> lives in App — keep shell content as <view> to avoid nested pages.
   return (
-    <LynxPage
-      auto-height
+    <LynxView
       style={{
         flexGrow: 1,
+        width: '100%',
+        height: '100%',
         position: 'relative',
         backgroundColor: cssVar('surface.background'),
       }}
@@ -441,6 +443,6 @@ export function LynxShellApp({
         onTabSelected={selectTab}
       />
       </LynxShellDialogPortalProvider>
-    </LynxPage>
+    </LynxView>
   );
 }

--- a/scripts/lynx-android-emulator-smoke.sh
+++ b/scripts/lynx-android-emulator-smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Emulator smoke: install Lynx sideload APK, launch HostActivity, require template
-# load / JS splash evidence AND stay alive (no FATAL / JS crash / assets open failure).
-# Mirrors scripts/expo-android-emulator-smoke.sh (logcat gates only — no screencap).
+# Emulator smoke: install Lynx sideload APK, launch HostActivity, require VISIBLE UI
+# text (uiautomator) and/or JS splash log — template_load_success alone is TOO WEAK
+# (false green on cream void). Mirrors scripts/expo-android-emulator-smoke.sh.
 set -euo pipefail
 
 APK=$(ls dist/*.apk | head -n 1)
@@ -22,7 +22,30 @@ LOGCAT_PID=$!
 
 adb shell am start -W -n "$PKG/$ACTIVITY" | tee emulator-smoke/am-start.txt
 
-SAW_LYNX=0
+SAW_UI=0
+SAW_SPLASH_LOG=0
+UI_EVIDENCE=""
+
+dump_ui_hierarchy() {
+  # Prefer uiautomator dump → pull XML; fall back to dumpsys activity / accessibility.
+  local dump_path="/sdcard/openchamber-lynx-ui.xml"
+  adb shell uiautomator dump "$dump_path" >/dev/null 2>&1 || true
+  if adb pull "$dump_path" emulator-smoke/ui.xml >/dev/null 2>&1; then
+    cat emulator-smoke/ui.xml
+    return 0
+  fi
+  adb shell dumpsys activity top 2>/dev/null || true
+  adb shell dumpsys accessibility 2>/dev/null | head -n 200 || true
+}
+
+ui_has_splash_text() {
+  local blob="$1"
+  if printf '%s' "$blob" | grep -Eq 'Connecting|OpenChamber Lynx|正在连接'; then
+    return 0
+  fi
+  return 1
+}
+
 for i in $(seq 1 60); do
   sleep 2
   adb logcat -d -v brief > emulator-smoke/logcat-snapshot.txt || true
@@ -55,13 +78,20 @@ for i in $(seq 1 60); do
     exit 1
   fi
 
-  # Proof Lynx/JS entered (Expo equivalent of ReactNativeJS Running "main"):
-  # host template_load_success / first_screen, or splash console line, or LynxView render.
-  # Prefer JS splash log (proof ConnectWelcome mounted). Fall back to template_load_success
-  # only after JS-error gates above have passed.
-  if grep -Fq '[OpenChamberLynx] ConnectWelcome splash' emulator-smoke/logcat-snapshot.txt \
-    || grep -Eq 'OpenChamberLynx.*(ConnectWelcome splash|template_load_success|first_screen)' emulator-smoke/logcat-snapshot.txt; then
-    SAW_LYNX=1
+  if grep -Fq '[OpenChamberLynx] ConnectWelcome splash' emulator-smoke/logcat-snapshot.txt; then
+    SAW_SPLASH_LOG=1
+  fi
+
+  # STRICT: require proof of UI text — not template_load_success alone (cream void false green).
+  if [ "$SAW_UI" != "1" ] && [ "$i" -ge 3 ]; then
+    UI_BLOB=$(dump_ui_hierarchy 2>/dev/null || true)
+    printf '%s\n' "$UI_BLOB" > emulator-smoke/ui-latest.txt
+    if ui_has_splash_text "$UI_BLOB"; then
+      SAW_UI=1
+      UI_EVIDENCE=$(printf '%s\n' "$UI_BLOB" | grep -E 'Connecting|OpenChamber Lynx|正在连接' | head -n 3 || true)
+      echo "OK: uiautomator/UI text evidence at attempt $i"
+      echo "$UI_EVIDENCE"
+    fi
   fi
 
   if ! adb shell pidof "$PKG" >/dev/null 2>&1; then
@@ -73,10 +103,11 @@ for i in $(seq 1 60); do
     fi
   fi
 
-  # After Lynx/JS evidence, dwell ~10s more and require process still alive.
-  if [ "$SAW_LYNX" = "1" ] && [ "$i" -ge 8 ]; then
+  # Pass only with UI text proof (preferred) or splash console line if it reaches logcat.
+  # template_load_success / first_screen alone MUST NOT pass.
+  if { [ "$SAW_UI" = "1" ] || [ "$SAW_SPLASH_LOG" = "1" ]; } && [ "$i" -ge 8 ]; then
     if adb shell pidof "$PKG" >/dev/null 2>&1; then
-      echo "OK: Lynx template/JS evidence + process alive at attempt $i"
+      echo "OK: UI/splash evidence + process alive at attempt $i (ui=$SAW_UI splash_log=$SAW_SPLASH_LOG)"
       break
     fi
   fi
@@ -87,6 +118,17 @@ kill "$LOGCAT_PID" >/dev/null 2>&1 || true
 wait "$LOGCAT_PID" 2>/dev/null || true
 adb logcat -d -v threadtime > emulator-smoke/logcat-full.txt || true
 
+# Final UI dump for artifacts
+FINAL_UI=$(dump_ui_hierarchy 2>/dev/null || true)
+printf '%s\n' "$FINAL_UI" > emulator-smoke/ui-final.txt
+if [ "$SAW_UI" != "1" ] && ui_has_splash_text "$FINAL_UI"; then
+  SAW_UI=1
+  UI_EVIDENCE=$(printf '%s\n' "$FINAL_UI" | grep -E 'Connecting|OpenChamber Lynx|正在连接' | head -n 3 || true)
+fi
+if [ "$SAW_SPLASH_LOG" != "1" ] && grep -Fq '[OpenChamberLynx] ConnectWelcome splash' emulator-smoke/logcat-full.txt; then
+  SAW_SPLASH_LOG=1
+fi
+
 {
   echo "=== am start ==="
   cat emulator-smoke/am-start.txt || true
@@ -94,12 +136,17 @@ adb logcat -d -v threadtime > emulator-smoke/logcat-full.txt || true
   echo "=== pidof ==="
   adb shell pidof "$PKG" || echo "(no pid)"
   echo ""
+  echo "=== UI evidence ==="
+  echo "SAW_UI=$SAW_UI SAW_SPLASH_LOG=$SAW_SPLASH_LOG"
+  echo "$UI_EVIDENCE"
+  echo ""
   echo "=== filtered (OpenChamberLynx / LynxView / AndroidRuntime) ==="
-  grep -E "OpenChamberLynx|LynxView|AndroidRuntime|JavascriptException|FATAL EXCEPTION|main\.lynx\.bundle|ConnectWelcome" emulator-smoke/logcat-full.txt || echo "(no matches)"
+  grep -E "OpenChamberLynx|LynxView|AndroidRuntime|JavascriptException|FATAL EXCEPTION|main\.lynx\.bundle|ConnectWelcome|first_screen_measured" emulator-smoke/logcat-full.txt || echo "(no matches)"
 } | tee emulator-smoke/logcat-evidence.txt
 
-if [ "$SAW_LYNX" != "1" ]; then
-  echo "::error::Timed out without Lynx template/JS evidence — black screen / failed load?"
+if [ "$SAW_UI" != "1" ] && [ "$SAW_SPLASH_LOG" != "1" ]; then
+  echo "::error::Timed out without UI text or ConnectWelcome splash log — cream void / false template_load_success?"
+  echo "::error::template_load_success alone is NOT sufficient (strict smoke)."
   exit 1
 fi
 
@@ -128,4 +175,4 @@ if grep -Fq 'OpenChamberLynx: Lynx JS error' emulator-smoke/logcat-full.txt; the
   exit 1
 fi
 
-echo "PASS: emulator smoke past Lynx template load and process stable"
+echo "PASS: emulator smoke — UI text or splash log proven (not template_load_success alone)"


### PR DESCRIPTION
## Summary
- **Root cause:** App entry mounted ConnectWelcome under bare Lynx `<view>` (no root `<page>`), while ShellApp already used `<page>`. Lynx first-screen without a root page often paints blank while the host cream FrameLayout shows → white/cream void. Additionally `src/index.tsx` only `export default App` without ReactLynx `root.render(<App />)`, so the card may never mount (no `[OpenChamberLynx] ConnectWelcome splash` in logcat). Smoke gated on `template_load_success` alone → false green.
- **Fix:** Wrap App ConnectWelcome + LynxShellApp returns in `<LynxPage>` (100% / flexGrow / `#fffdf4`); ShellApp outer becomes `<view>` to avoid nested pages; hard-coded splash `OpenChamber Lynx` + `Connecting…` (i18n secondary); `root.render` in `index.tsx`; host `requestLayout` + measured WxH after `first_screen` (error TextView if 0x0); strict smoke requires uiautomator UI text or splash console line — **not** template_load_success alone.

## Test plan
- [ ] lynx-mobile-ci emulator smoke PASSes with UI dump matching `Connecting` / `OpenChamber Lynx`
- [ ] New prerelease `lynx-v2-debug-<sha7>` shows splash text on device (not cream void)
- [ ] No nested `<page>` regressions on shell tabs after connect