### PR TITLE
fix(lynx): drop explicit page tag (Android BehaviorController)

### DIFF
--- a/packages/lynx/src/App.tsx
+++ b/packages/lynx/src/App.tsx
@@ -16,12 +16,16 @@ import {
   type LynxAutoConnectPhase,
 } from './connect/autoConnectPhase';
 import { createHostGlobalProps, type LynxHostGlobalProps } from './host/embedding';
-import { LynxPage } from './lynx-elements';
+import { LynxView } from './lynx-elements';
 import { createSessionIndexHomeBindings, createLynxSessionIndexStore } from './session-index/store';
 import { LynxShellApp } from './shell/ShellApp';
 
-/** Root `<page>` styles — Lynx first-screen without page often paints blank cream. */
-const ROOT_PAGE_STYLE = {
+/**
+ * Full-bleed root styles under ReactLynx's implicit page (from root.render).
+ * Do NOT emit an explicit `<page>` element — Android BehaviorRegistry has no
+ * BehaviorController for tag `page` (createUI fails → cream void + host error).
+ */
+const ROOT_VIEW_STYLE = {
   width: '100%',
   height: '100%',
   flexGrow: 1,
@@ -123,7 +127,7 @@ export function App({
 
   if (gate.kind === 'splash' || gate.kind === 'welcome') {
     return (
-      <LynxPage style={ROOT_PAGE_STYLE} accessibility-label="OpenChamber Lynx">
+      <LynxView style={ROOT_VIEW_STYLE} accessibility-label="OpenChamber Lynx">
         <ConnectWelcome
           locale={resolved.locale}
           phase={phase}
@@ -137,12 +141,12 @@ export function App({
           onPendingChange={setPending}
           onError={setError}
         />
-      </LynxPage>
+      </LynxView>
     );
   }
 
   return (
-    <LynxPage style={ROOT_PAGE_STYLE} auto-height accessibility-label="OpenChamber Lynx">
+    <LynxView style={ROOT_VIEW_STYLE} accessibility-label="OpenChamber Lynx">
       <LynxShellApp
         host={resolved}
         runtimeFetch={client.runtimeFetch}
@@ -153,6 +157,6 @@ export function App({
         onConnected={() => setConnected(true)}
         lynxClientVersion={lynxClientVersion}
       />
-    </LynxPage>
+    </LynxView>
   );
 }

--- a/packages/lynx/src/lynx-elements.tsx
+++ b/packages/lynx/src/lynx-elements.tsx
@@ -64,6 +64,11 @@ function lynxElement(type: string, props: object): ReactNode {
   return createElement(type, props);
 }
 
+/**
+ * Prefer ReactLynx `root.render` (implicit page) + `<LynxView>` roots.
+ * Emitting an explicit `<page>` tag crashes Android hosts that only register
+ * XElementBehaviors — BehaviorRegistry has no controller for `page`.
+ */
 export function LynxPage(props: LynxPageProps) {
   return lynxElement('page', props);
 }

--- a/scripts/lynx-android-emulator-smoke.sh
+++ b/scripts/lynx-android-emulator-smoke.sh
@@ -71,6 +71,14 @@ for i in $(seq 1 60); do
     exit 1
   fi
 
+  # Explicit <page> JSX is fatal on this Android host (no BehaviorController for tag page).
+  if grep -Eqi 'No BehaviorController defined for class page|createUI catch error while createUI for tag: page' emulator-smoke/logcat-snapshot.txt; then
+    echo "::error::Lynx explicit <page> tag failed — use ReactLynx root.render implicit page + <view> roots"
+    grep -Ei 'BehaviorController defined for class page|createUI for tag: page|OpenChamberLynx: Lynx error' emulator-smoke/logcat-snapshot.txt | tail -20 || true
+    kill "$LOGCAT_PID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+
   if grep -Eq "Process: ${PKG}" emulator-smoke/logcat-snapshot.txt && grep -Eq 'FATAL EXCEPTION|JavascriptException' emulator-smoke/logcat-snapshot.txt; then
     echo "::error::FATAL / JavascriptException for $PKG"
     grep -E "OpenChamberLynx|LynxView|FATAL EXCEPTION|JavascriptException|AndroidRuntime" emulator-smoke/logcat-snapshot.txt | tail -60 || true
@@ -172,6 +180,11 @@ fi
 
 if grep -Fq 'OpenChamberLynx: Lynx JS error' emulator-smoke/logcat-full.txt; then
   echo "::error::OpenChamberLynx Lynx JS error present in full logcat"
+  exit 1
+fi
+
+if grep -Eqi 'No BehaviorController defined for class page|createUI catch error while createUI for tag: page' emulator-smoke/logcat-full.txt; then
+  echo "::error::explicit <page> BehaviorController failure present in full logcat"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- CI log for #68 showed ConnectWelcome **did** mount (`[OpenChamberLynx] ConnectWelcome splash`) after `root.render`, but paint still failed: `No BehaviorController defined for class page` / `createUI ... tag: page`.
- Root cause refinement: ReactLynx `root.render` provides the implicit page; **explicit** `<LynxPage>` / `page` JSX is not registered on this Android host.
- Replace App root wrappers with full-bleed `<LynxView>`; document LynxPage hazard; smoke fails on that BehaviorController error (uiautomator often cannot see Lynx text nodes).

## Test plan
- [ ] Lynx Mobile CI green
- [ ] Smoke log has splash line and **no** `BehaviorController defined for class page`
- [ ] New `lynx-v2-debug-<sha7>` shows Connecting… / OpenChamber Lynx