### PR TITLE
feat(lynx): Cap server message-queue client (#41)

### DIFF
--- a/docs/lynx-acceptance.md
+++ b/docs/lynx-acceptance.md
@@ -287,3 +287,11 @@ Chosen mode is written at the top of `packages/lynx/README.md` (Mode B iOS 26 ho
 - Helpers: Cap filter / preserve-active-project resolvers + session-index related list; shell chip → openChat; "All" → Projects home analogue.
 - Product **NOT DONE** / 三关未齐 / not EXHAUSTED / 真机残差 empty / no 真机过 claim.
 
+## Notes — Cap server message-queue client (Next #41 / 2026-09-08)
+
+- Tip APK: `lynx-v2-debug-c02f917` (work/lynx-native @ `c02f917f`; release exists). Do not invent a newer APK SHA until mobile-ci rebuilds.
+- Thin Cap `/api/openchamber/message-queue` client (`messageQueueServer.ts`) over `LynxRuntimeFetch`: list/admit/reorder/remove/send-now (flush = send-now first). Honest parse; no-runtime/HTTP never fake-success.
+- `composerActions` prefers server when reachable; unavailable → local queue. QueuedMessageChips keep portable ↑/↓ (no `@dnd-kit` / no TanStack).
+- Full Cap sessions sheet / TanStack MQ sync still deferred; host-only unchanged.
+- Product **NOT DONE** / 三关未齐 / not EXHAUSTED / 真机残差 empty / no 真机过 claim.
+

--- a/docs/lynx-gap-board.md
+++ b/docs/lynx-gap-board.md
@@ -351,6 +351,7 @@ First implementation slice after this doc gate (order is deliberate: connect →
 38. ~~**QueuedMessageChips + SessionGoalRow**~~ — 代码接上 in `cursor/lynx-queue-chips-goal-local`. Cap queue chips + SessionGoal strip above composer glass; local `composerActions` queue with remove/send-now + portable ↑/↓ reorder (Cap `@dnd-kit` / server `/api/openchamber/message-queue` deferred). SessionGoal GET+PATCH metadata + optional `/api/goals/objective`; never fake-success. **MobileSessionStatusBar deferred** (Cap file large — follow-up). Docs honesty: tip APK `lynx-v2-debug-905c42e`; product NOT DONE / 三关未齐 / not EXHAUSTED; 真机残差 empty.
 39. ~~**MobileSessionStatusBar slim strip**~~ — 代码接上 in `cursor/lynx-session-status-bar-local`. Cap multi-session status bar **thin** parity (not full ~1900-line sheet): related session chips + busy/working indicator above composer with SessionGoal + queue chips; Cap filter/preserve-active-project resolvers; session-index related list from shell; full Cap sessions sheet / worktree menus / server message-queue deferred. Docs honesty: tip APK `lynx-v2-debug-ca32a72` (release exists); product NOT DONE / 三关未齐 / not EXHAUSTED; 真机残差 empty.
 40. ~~**SessionGoal create/manage dialog**~~ — 代码接上 in `cursor/lynx-session-goal-dialog-local`. Cap `SessionGoalDialog` + `setSessionGoal`/`clearSessionGoal` parity: Lynx `setLynxSessionGoal`/`clearLynxSessionGoal` (GET `/session/:id` + PATCH `metadata.openchamber.goal` + Cap `/api/goals/objective/:id`); create/manage overlay via shell `LynxCenteredDialog`/`LynxDialogPortal`; row tap → manage; create entry when no goal + Cap `/goal` arm (never auto-send). Complete via existing `setLynxSessionGoalStatus('complete')`. Docs honesty: tip `8def01d0` / tip APK `lynx-v2-debug-8def01d` (release exists); product NOT DONE / 三关未齐 / not EXHAUSTED; 真机残差 empty.
+41. ~~**Cap server message-queue client + QueuedMessageChips wire**~~ — 代码接上 in `cursor/lynx-message-queue-server-local`. Thin Cap-compatible `messageQueueServer.ts` over `LynxRuntimeFetch` (list/admit/reorder/remove/send-now; flush=send-now first); composerActions prefers server when reachable, falls back to local on unavailable; portable ↑/↓ (no `@dnd-kit` / no TanStack). Docs honesty: tip `c02f917f` / tip APK `lynx-v2-debug-c02f917` (release exists); product NOT DONE / 三关未齐 / not EXHAUSTED; 真机残差 empty; full Cap sessions sheet still deferred; host-only unchanged.
 
 Do not invent ASR / Bonjour / Capgo / TanStack 1.18. Share / Live Activity / widgets stay later.
 
@@ -620,7 +621,7 @@ Slice on `cursor/lynx-dialog-portal-theme-local` (base PR#61 tip `7a4c7b6a8`; PR
 
 ## Remaining (honest — not EXHAUSTED)
 
-**Product NOT DONE / 三关未齐 / not EXHAUSTED.** Linux Cap product rows continue to close on tip `8def01d0` + follow-ons (connect/settings/chat/projects/changes + Android first-paint #65–#69 + Cap phone overflow **new-session** in Next #32 + Voice model download/delete UI in Next #33 + Voice STT select + Changes dirty badge in Next #34 + PermissionCard metadata + permission auto-accept in Next #35 + Cap share-recipient picker in Next #36 + Projects menus/share in Next #37 + QueuedMessageChips + SessionGoalRow in Next #38 + MobileSessionStatusBar slim strip in Next #39 + SessionGoal create/manage dialog in Next #40). Queue chips + SessionGoal row/dialog + slim session status bar JS 代码接上 in #38–#40; **full Cap MobileSessionStatusBar sheet still deferred**. Remaining Cap-parity polish is thin; **host binders / HTML WKWebView / Pierre `@pierre/diffs` (honest DOM blocker — not ported) / Live Activity / iOS IPA / Share extension + ShareReceiverActivity / clipboard host / Cap server message-queue / 真机** still block EXHAUSTED. **Do not** mark landed under 三关. 真机残差: **empty** (no written device log). Tip APK: `lynx-v2-debug-8def01d` — release exists; do not invent a newer APK SHA until mobile-ci rebuilds.
+**Product NOT DONE / 三关未齐 / not EXHAUSTED.** Linux Cap product rows continue to close on tip `c02f917f` + follow-ons (connect/settings/chat/projects/changes + Android first-paint #65–#69 + Cap phone overflow **new-session** in Next #32 + Voice model download/delete UI in Next #33 + Voice STT select + Changes dirty badge in Next #34 + PermissionCard metadata + permission auto-accept in Next #35 + Cap share-recipient picker in Next #36 + Projects menus/share in Next #37 + QueuedMessageChips + SessionGoalRow in Next #38 + MobileSessionStatusBar slim strip in Next #39 + SessionGoal create/manage dialog in Next #40 + Cap server message-queue client in Next #41). Queue chips + SessionGoal row/dialog + slim session status bar + server MQ client JS 代码接上 in #38–#41; **full Cap MobileSessionStatusBar sheet still deferred**. Remaining Cap-parity polish is thin; **host binders / HTML WKWebView / Pierre `@pierre/diffs` (honest DOM blocker — not ported) / Live Activity / iOS IPA / Share extension + ShareReceiverActivity / clipboard host / 真机** still block EXHAUSTED. **Do not** mark landed under 三关. 真机残差: **empty** (no written device log). Tip APK: `lynx-v2-debug-c02f917` — release exists; do not invent a newer APK SHA until mobile-ci rebuilds.
 
 ### 代码接上 prior slice (`cursor/lynx-closable-missing-local` / PR#48)
 
@@ -837,7 +838,7 @@ Slice on `cursor/lynx-dialog-portal-theme-local` (base PR#61 tip `7a4c7b6a8`; PR
 | Item | Notes |
 |---|---|
 | QueuedMessageChips | Cap chips above composer; Lynx `LynxQueuedMessageChips` + `queuedMessageChips.ts` on local `composerActions` queue — remove / send-now / flush; portable ↑/↓ reorder (no `@dnd-kit`) |
-| Server message-queue | Cap `/api/openchamber/message-queue` + TanStack mutation flights **deferred** — local queue only this slice |
+| Server message-queue | Cap `/api/openchamber/message-queue` thin client 代码接上 in Next #41; TanStack/Zustand flights still deferred |
 | SessionGoalRow | Cap compact strip; Lynx `sessionGoal.ts` + `LynxSessionGoalRow` via GET `/session/:id` metadata + PATCH status; file objective GET `/api/goals/objective/:id` when `objectiveFile`; never fake-success |
 | MobileSessionStatusBar (full Cap sheet) | Slim strip 代码接上 in Next #39; **full** Cap ~1900-line sheet (worktree groups / long-press menus / MobileWindowMotion) still deferred |
 | Docs honesty | Tip APK `lynx-v2-debug-905c42e`; Next #38 |
@@ -850,7 +851,7 @@ Slice on `cursor/lynx-dialog-portal-theme-local` (base PR#61 tip `7a4c7b6a8`; PR
 | Slim MobileSessionStatusBar | Cap related-session chips + busy/working indicator above composer (with SessionGoal + queue); **not** full Cap sheet |
 | Pure helpers | Cap `shouldPreserveActiveProjectOnSessionOpen` + `resolveMobileSessionSheetDefaultFilter`; status normalize; session-index related list |
 | Shell wiring | session-index → relatedSessions / orderedSessionIds; chip tap → openChat; "All" → Projects home (honest Cap sheet analogue) |
-| Deferred | Full Cap sessions sheet / worktree collapse / long-press menus / server message-queue / `@dnd-kit` |
+| Deferred | Full Cap sessions sheet / worktree collapse / long-press menus / `@dnd-kit` (server MQ thin client in #41) |
 | Docs honesty | Tip APK `lynx-v2-debug-ca32a72` (release exists); Next #39 |
 | Docs honesty | NOT DONE / 三关未齐 / not EXHAUSTED / 真机残差 empty / no 真机过 claim |
 
@@ -864,6 +865,17 @@ Slice on `cursor/lynx-dialog-portal-theme-local` (base PR#61 tip `7a4c7b6a8`; PR
 | Complete | Cap complete via existing `setLynxSessionGoalStatus('complete')` |
 | Docs honesty | Tip `8def01d0` / APK `lynx-v2-debug-8def01d` (release exists); Next #40 |
 | Docs honesty | NOT DONE / 三关未齐 / not EXHAUSTED / 真机残差 empty / no 真机过 claim |
+
+### 代码接上 this slice (`cursor/lynx-message-queue-server-local` / Next #41)
+
+| Item | Notes |
+|---|---|
+| messageQueueServer.ts | Cap-compatible HTTP helpers over `LynxRuntimeFetch`: list/get scope (directory+session), admit text, reorder by queueItemIDs, remove, send-now, flush→send-now first; honest parse; no-runtime/HTTP never fake-success |
+| composer + chips wire | Prefer server queue when runtime reachable; unavailable (501/transport) → local queue; chips keep portable ↑/↓ (no `@dnd-kit`) |
+| Vitest | Happy-path parse + failure paths (`messageQueueServer.test.ts`) + composer server/local coverage |
+| Docs honesty | Tip `c02f917f` / APK `lynx-v2-debug-c02f917` (release exists); Next #41 |
+| Docs honesty | NOT DONE / 三关未齐 / not EXHAUSTED / 真机残差 empty / no 真机过 claim |
+| Still deferred | Full Cap sessions sheet; Cap TanStack/Zustand MQ sync flights; `@dnd-kit`; host-only unchanged |
 
 ### Still missing / host-only / 真机
 
@@ -881,7 +893,7 @@ Slice on `cursor/lynx-dialog-portal-theme-local` (base PR#61 tip `7a4c7b6a8`; PR
 | Share extension / Android `ShareReceiverActivity` | **Host-only** (separate from Next #36 JS full-page picker). Inbox + recipient picker 代码接上; native extension/receiver still host |
 | Native clipboard binder | Next #37 copyLink uses `navigator.clipboard` when present; otherwise labeled unavailable — host clipboard plugin still host-only |
 | MobileSessionStatusBar (full Cap sheet) | Slim related-session + busy strip 代码接上 in #39; full Cap sheet chrome still deferred |
-| Cap server message-queue | `/api/openchamber/message-queue` + DnD-kit — deferred; Lynx local queue chips 代码接上 in #38 |
+| Cap server message-queue | Thin Lynx client 代码接上 in #41 (`messageQueueServer` + composer wire); full Cap TanStack/Zustand sync + `@dnd-kit` still deferred |
 | Live Activity / Widgets / Control Center | iOS-only host — later |
 | Android sideload APK + lynx-ci | **Live** on tip (`lynx-mobile-ci` assembleRelease + prerelease `lynx-v2-debug-*`; lynx-ci green). First-paint cream/globalProps 代码接上 — **not** 真机过. |
 | iOS IPA / CocoaPods Lynx resolve | Still missing on Linux; Mac/device required |

--- a/packages/lynx/src/chat/ChatScreen.tsx
+++ b/packages/lynx/src/chat/ChatScreen.tsx
@@ -306,6 +306,16 @@ export function LynxChatScreen({
     setSendingQueueIds(new Set());
     setGoalArmed(false);
     setGoalDialogOpen(false);
+    let cancelled = false;
+    void (async () => {
+      const result = await composer.refreshQueue();
+      if (cancelled) return;
+      if (result.status !== 'ok' && result.reason !== 'no-runtime') {
+        setActionError(`${result.reason}: ${result.error}`);
+      }
+      syncQueueFromComposer();
+    })();
+    return () => { cancelled = true; };
   }, [composer, syncQueueFromComposer]);
 
 
@@ -784,12 +794,15 @@ export function LynxChatScreen({
 
   const onQueueRemove = useCallback((id: string) => {
     setActionError(null);
-    const result = composer.removeFromQueue(id);
-    if (result.status !== 'ok') {
-      setActionError(`${result.reason}: ${result.error}`);
-      return;
-    }
-    syncQueueFromComposer();
+    void (async () => {
+      const result = await composer.removeFromQueue(id);
+      if (result.status !== 'ok') {
+        setActionError(`${result.reason}: ${result.error}`);
+        syncQueueFromComposer();
+        return;
+      }
+      syncQueueFromComposer();
+    })();
   }, [composer, syncQueueFromComposer]);
 
   const onQueueSendNow = useCallback(async (id: string) => {
@@ -823,12 +836,15 @@ export function LynxChatScreen({
     const to = direction === 'up' ? from - 1 : from + 1;
     const over = current[to];
     if (!over) return;
-    const result = composer.reorderQueue(id, over.id);
-    if (result.status !== 'ok') {
-      setActionError(`${result.reason}: ${result.error}`);
-      return;
-    }
-    syncQueueFromComposer();
+    void (async () => {
+      const result = await composer.reorderQueue(id, over.id);
+      if (result.status !== 'ok') {
+        setActionError(`${result.reason}: ${result.error}`);
+        syncQueueFromComposer();
+        return;
+      }
+      syncQueueFromComposer();
+    })();
   }, [composer, syncQueueFromComposer]);
 
   const onQuestionReply = useCallback(async (requestId: string, answers: string[][]) => {

--- a/packages/lynx/src/chat/QueuedMessageChips.tsx
+++ b/packages/lynx/src/chat/QueuedMessageChips.tsx
@@ -1,9 +1,9 @@
 /**
- * Cap QueuedMessageChips spirit for Lynx — local queue chips above composer.
+ * Cap QueuedMessageChips spirit for Lynx — queue chips above composer.
  *
  * Placement: sibling ABOVE LynxComposerGlassCard (Cap composer-queue stack).
- * Reorder: portable ↑/↓ (Cap @dnd-kit deferred — document honesty).
- * Trailing: SessionGoal strip shares the same shell when present.
+ * Source: Cap server message-queue when wired via composerActions; else local.
+ * Reorder: portable ↑/↓ (no @dnd-kit). Trailing: SessionGoal strip when present.
  */
 import type { ReactNode } from 'react';
 

--- a/packages/lynx/src/chat/composerActions.test.ts
+++ b/packages/lynx/src/chat/composerActions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { createLynxComposerActions } from './composerActions';
+import { LYNX_MESSAGE_QUEUE_ROUTE } from './messageQueueServer';
 
 describe('Lynx composer send/stop/queue', () => {
   test('without runtime never fake-succeeds', async () => {
@@ -14,7 +15,7 @@ describe('Lynx composer send/stop/queue', () => {
     expect(await actions.queue('hi')).toMatchObject({ status: 'failed', reason: 'no-runtime' });
   });
 
-  test('send and stop call official APIs; queue flushes via prompt_async', async () => {
+  test('send and stop call official APIs; unavailable MQ falls back to local queue', async () => {
     const calls: string[] = [];
     const runtimeFetch = async (path: string, init?: { method?: string; body?: string }) => {
       calls.push(`${init?.method ?? 'GET'} ${path}`);
@@ -23,6 +24,10 @@ describe('Lynx composer send/stop/queue', () => {
       }
       if (path.includes('/abort')) {
         return { ok: true, status: 200, json: async () => true };
+      }
+      // Cap MQ unavailable → local queue path
+      if (path.includes(LYNX_MESSAGE_QUEUE_ROUTE)) {
+        return { ok: false, status: 501, json: async () => ({ code: 'unavailable' }) };
       }
       return { ok: false, status: 404, json: async () => ({}) };
     };
@@ -46,6 +51,7 @@ describe('Lynx composer send/stop/queue', () => {
     });
     expect(await actions.queue('later')).toMatchObject({ status: 'ok', queuedId: 'q1' });
     expect(actions.getQueue()).toHaveLength(1);
+    expect(actions.getQueueMode()).toBe('local');
 
     expect(await actions.flushQueue()).toMatchObject({
       status: 'failed',
@@ -61,12 +67,15 @@ describe('Lynx composer send/stop/queue', () => {
 });
 
 describe('Lynx queue chip remove / sendNow / reorder', () => {
-  const make = () => {
+  const makeLocal = () => {
     const calls: string[] = [];
     const runtimeFetch = async (path: string, init?: { method?: string }) => {
       calls.push(`${init?.method ?? 'GET'} ${path}`);
       if (path.includes('prompt_async')) {
         return { ok: true, status: 204, json: async () => true };
+      }
+      if (path.includes(LYNX_MESSAGE_QUEUE_ROUTE)) {
+        return { ok: false, status: 501, json: async () => ({ code: 'unavailable' }) };
       }
       return { ok: false, status: 404, json: async () => ({}) };
     };
@@ -82,14 +91,14 @@ describe('Lynx queue chip remove / sendNow / reorder', () => {
     return { actions, calls, setWorking: (v: boolean) => { working = v; } };
   };
 
-  test('remove / reorder / sendNow on local queue', async () => {
-    const { actions, setWorking } = make();
+  test('remove / reorder / sendNow on local queue after MQ unavailable', async () => {
+    const { actions, setWorking } = makeLocal();
     expect(await actions.queue('one')).toMatchObject({ status: 'ok', queuedId: 'q1' });
     expect(await actions.queue('two')).toMatchObject({ status: 'ok', queuedId: 'q2' });
     expect(await actions.queue('three')).toMatchObject({ status: 'ok', queuedId: 'q3' });
-    expect(actions.reorderQueue('q3', 'q1')).toMatchObject({ status: 'ok' });
+    expect(await actions.reorderQueue('q3', 'q1')).toMatchObject({ status: 'ok' });
     expect(actions.getQueue().map((q) => q.id)).toEqual(['q3', 'q1', 'q2']);
-    expect(actions.removeFromQueue('q1')).toMatchObject({ status: 'ok' });
+    expect(await actions.removeFromQueue('q1')).toMatchObject({ status: 'ok' });
     expect(actions.getQueue().map((q) => q.id)).toEqual(['q3', 'q2']);
 
     setWorking(true);
@@ -99,13 +108,140 @@ describe('Lynx queue chip remove / sendNow / reorder', () => {
     expect(actions.getQueue().map((q) => q.id)).toEqual(['q2']);
   });
 
-  test('chip ops without runtime fail honestly', () => {
+  test('chip ops without runtime fail honestly', async () => {
     const actions = createLynxComposerActions({
       sessionId: 'ses_1',
       model: { providerID: 'a', modelID: 'b' },
       sessionApi: null,
     });
-    expect(actions.removeFromQueue('x')).toMatchObject({ status: 'failed', reason: 'no-runtime' });
-    expect(actions.reorderQueue('a', 'b')).toMatchObject({ status: 'failed', reason: 'no-runtime' });
+    expect(await actions.removeFromQueue('x')).toMatchObject({ status: 'failed', reason: 'no-runtime' });
+    expect(await actions.reorderQueue('a', 'b')).toMatchObject({ status: 'failed', reason: 'no-runtime' });
+  });
+});
+
+describe('Lynx composer Cap server message-queue', () => {
+  test('prefer server admit/list/reorder/remove/send-now; never fake on HTTP failure', async () => {
+    const item = {
+      queueItemID: 'queued-q1',
+      operationID: 'operation-q1',
+      messageID: 'msg_q1',
+      content: 'hello',
+      status: 'queued',
+      attemptCount: 0,
+      position: 0,
+      rowVersion: 1,
+      createdAt: 10,
+    };
+    let revision = 1;
+    let items = [] as typeof item[];
+    const calls: string[] = [];
+
+    const runtimeFetch = async (path: string, init?: { method?: string; body?: string }) => {
+      const method = init?.method ?? 'GET';
+      calls.push(`${method} ${path}`);
+      if (method === 'GET' && path === LYNX_MESSAGE_QUEUE_ROUTE) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            revision,
+            scopes: items.length
+              ? [{
+                scopeID: 'scope/a',
+                revision,
+                directory: '/repo',
+                sessionID: 'ses_1',
+                worktreeState: 'active',
+                itemCount: items.length,
+              }]
+              : [],
+            worktreeOrders: [],
+          }),
+        };
+      }
+      if (method === 'GET' && path.includes('/scopes/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            scopeID: 'scope/a',
+            revision,
+            directory: '/repo',
+            sessionID: 'ses_1',
+            worktreeState: 'active',
+            itemCount: items.length,
+            items,
+          }),
+        };
+      }
+      if (method === 'POST' && path.endsWith('/items')) {
+        revision += 1;
+        items = [{ ...item, rowVersion: 1, content: JSON.parse(init?.body ?? '{}').item.content }];
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            revision,
+            scopeID: 'scope/a',
+            queueItemID: item.queueItemID,
+            rowVersion: 1,
+          }),
+        };
+      }
+      if (method === 'PUT' && path.includes('/order')) {
+        const ids = JSON.parse(init?.body ?? '{}').queueItemIDs as string[];
+        revision += 1;
+        items = ids.map((id, index) => ({
+          ...items.find((entry) => entry.queueItemID === id)!,
+          position: index,
+        }));
+        return { ok: true, status: 200, json: async () => ({ revision, scopeID: 'scope/a' }) };
+      }
+      if (method === 'DELETE' && path.includes('/items/')) {
+        revision += 1;
+        items = [];
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ revision, removedQueueItemID: item.queueItemID }),
+        };
+      }
+      if (method === 'POST' && path.includes('/send')) {
+        return { ok: false, status: 409, json: async () => ({ code: 'revision_conflict' }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    };
+
+    const actions = createLynxComposerActions({
+      sessionId: 'ses_1',
+      directory: '/repo',
+      model: { providerID: 'anthropic', modelID: 'claude' },
+      sessionApi: { runtimeFetch },
+      createId: () => 'q1',
+      now: () => 10,
+    });
+
+    expect(await actions.queue('hello')).toMatchObject({ status: 'ok', queuedId: 'queued-q1' });
+    expect(actions.getQueueMode()).toBe('server');
+    expect(actions.getQueue().map((q) => q.id)).toEqual(['queued-q1']);
+    expect(calls.some((c) => c.includes(`${LYNX_MESSAGE_QUEUE_ROUTE}/items`))).toBe(true);
+
+    // Second item for reorder
+    items = [
+      { ...item, queueItemID: 'queued-q1', position: 0 },
+      { ...item, queueItemID: 'queued-q2', content: 'two', position: 1, operationID: 'operation-q2', messageID: 'msg_q2' },
+    ];
+    revision += 1;
+    expect(await actions.refreshQueue()).toMatchObject({ status: 'ok' });
+    expect(await actions.reorderQueue('queued-q2', 'queued-q1')).toMatchObject({ status: 'ok' });
+    expect(calls.some((c) => c.startsWith('PUT ') && c.includes('/order'))).toBe(true);
+
+    expect(await actions.sendNow('queued-q1')).toMatchObject({
+      status: 'failed',
+      reason: 'http',
+    });
+    expect(calls.some((c) => c.includes('/send'))).toBe(true);
+
+    expect(await actions.removeFromQueue('queued-q1')).toMatchObject({ status: 'ok' });
   });
 });

--- a/packages/lynx/src/chat/composerActions.ts
+++ b/packages/lynx/src/chat/composerActions.ts
@@ -3,8 +3,10 @@
  * When a connect runtime exists, calls official OpenCode routes.
  * Without a runtime, returns explicit failures — never fake-success.
  *
- * Queue is local until flush / send-now hits prompt_async (Cap local/legacy
- * path). Server `/api/openchamber/message-queue` is not wired here yet.
+ * Queue: prefer Cap `/api/openchamber/message-queue` when runtimeFetch can
+ * reach it (list/admit/reorder/remove/send-now; flush = send-now first).
+ * If the server is unavailable (501 / transport), keep the local queue path.
+ * Never invent server success.
  */
 import {
   abortSession,
@@ -12,6 +14,18 @@ import {
   type LynxSessionApiDeps,
 } from './sessionApi';
 import { reorderLynxQueueChips } from './queuedMessageChips';
+import {
+  admitLynxTextQueueItem,
+  fetchLynxMessageQueueScope,
+  fetchLynxMessageQueueScopeForSession,
+  flushLynxQueueScopeFirst,
+  isLynxMessageQueueUnavailable,
+  lynxQueueItemsToPrompts,
+  removeLynxQueueItem,
+  reorderLynxQueueScope,
+  sendLynxQueueItemNow,
+  type LynxMessageQueueScope,
+} from './messageQueueServer';
 
 export type LynxComposerModel = {
   providerID: string;
@@ -24,24 +38,30 @@ export type LynxQueuedPrompt = {
   id: string;
   text: string;
   createdAt: number;
+  /** Present when mirrored from Cap server message-queue. */
+  rowVersion?: number;
 };
 
 export type LynxComposerActionResult =
   | { status: 'ok'; messageId?: string; aborted?: true; queuedId?: string }
-  | { status: 'failed'; error: string; reason: 'no-runtime' | 'http' | 'invalid' | 'busy-steer-required' };
+  | { status: 'failed'; error: string; reason: 'no-runtime' | 'http' | 'invalid' | 'busy-steer-required' | 'unavailable' };
 
 export type LynxComposerActions = {
   send: (text: string, options?: { messageId?: string; delivery?: 'steer' }) => Promise<LynxComposerActionResult>;
   stop: () => Promise<LynxComposerActionResult>;
   queue: (text: string) => Promise<LynxComposerActionResult>;
   flushQueue: () => Promise<LynxComposerActionResult>;
-  /** Cap chip Send — prompt_async this item now (requires idle session). */
+  /** Cap chip Send — server send-now when authoritative; else prompt_async. */
   sendNow: (queueItemId: string) => Promise<LynxComposerActionResult>;
-  /** Cap chip Remove — drop from local queue. */
-  removeFromQueue: (queueItemId: string) => LynxComposerActionResult;
-  /** Portable reorder (Cap DnD-kit deferred — no @dnd-kit in Lynx). */
-  reorderQueue: (activeId: string, overId: string) => LynxComposerActionResult;
+  /** Cap chip Remove — server DELETE when authoritative; else local drop. */
+  removeFromQueue: (queueItemId: string) => Promise<LynxComposerActionResult>;
+  /** Portable reorder (no @dnd-kit) — server PUT order when authoritative. */
+  reorderQueue: (activeId: string, overId: string) => Promise<LynxComposerActionResult>;
+  /** Refresh chips from Cap server scope when authoritative; no-op on local. */
+  refreshQueue: () => Promise<LynxComposerActionResult>;
   getQueue: () => readonly LynxQueuedPrompt[];
+  /** 'server' | 'local' | 'unknown' (not yet probed). */
+  getQueueMode: () => 'server' | 'local' | 'unknown';
 };
 
 export type CreateLynxComposerActionsInput = {
@@ -50,9 +70,14 @@ export type CreateLynxComposerActionsInput = {
   model: LynxComposerModel;
   /** Null / undefined = not connected — actions fail honestly. */
   sessionApi: LynxSessionApiDeps | null;
-  /** When true, follow-ups go to the local queue instead of prompt_async. */
+  /** When true, follow-ups go to the local/server queue instead of prompt_async. */
   sessionIsWorking?: () => boolean;
   followUpBehavior?: 'steer' | 'queue';
+  /**
+   * Prefer Cap server message-queue when runtime is present (default true).
+   * Falls back to local queue only when the server reports unavailable.
+   */
+  preferServerQueue?: boolean;
   now?: () => number;
   createId?: () => string;
 };
@@ -61,9 +86,12 @@ export function createLynxComposerActions(
   input: CreateLynxComposerActionsInput,
 ): LynxComposerActions {
   let queue: LynxQueuedPrompt[] = [];
+  let queueMode: 'server' | 'local' | 'unknown' = 'unknown';
+  let serverScope: LynxMessageQueueScope | null = null;
   const now = input.now ?? (() => Date.now());
   const createId = input.createId ?? (() => `queue_${now().toString(36)}`);
   const followUpBehavior = input.followUpBehavior ?? 'queue';
+  const preferServerQueue = input.preferServerQueue !== false;
 
   const requireApi = (): LynxSessionApiDeps | LynxComposerActionResult => {
     if (!input.sessionApi) {
@@ -74,6 +102,80 @@ export function createLynxComposerActions(
       };
     }
     return input.sessionApi;
+  };
+
+  const runtimeFetch = () => input.sessionApi?.runtimeFetch;
+
+  const directory = () => (input.directory?.trim() || '/');
+
+  const applyServerScope = (scope: LynxMessageQueueScope | null) => {
+    serverScope = scope;
+    queueMode = 'server';
+    queue = scope ? lynxQueueItemsToPrompts(scope.items) : [];
+  };
+
+  const useLocalQueue = () => {
+    queueMode = 'local';
+    serverScope = null;
+  };
+
+  const refreshServerScope = async (): Promise<LynxComposerActionResult> => {
+    const api = requireApi();
+    if ('status' in api) return api;
+    const result = await fetchLynxMessageQueueScopeForSession(api.runtimeFetch, {
+      directory: directory(),
+      sessionID: input.sessionId,
+    });
+    if (result.status !== 'ok') {
+      if (isLynxMessageQueueUnavailable(result)) {
+        useLocalQueue();
+        return { status: 'ok' };
+      }
+      return {
+        status: 'failed',
+        error: result.error,
+        reason: result.reason === 'invalid' ? 'invalid' : 'http',
+      };
+    }
+    applyServerScope(result.value);
+    return { status: 'ok' };
+  };
+
+  const ensureQueueBackend = async (): Promise<'server' | 'local' | LynxComposerActionResult> => {
+    const api = requireApi();
+    if ('status' in api) return api;
+    if (!preferServerQueue) {
+      useLocalQueue();
+      return 'local';
+    }
+    if (queueMode === 'server') return 'server';
+    if (queueMode === 'local') return 'local';
+    const probed = await refreshServerScope();
+    if (probed.status !== 'ok') return probed;
+    return queueMode === 'server' ? 'server' : 'local';
+  };
+
+  const reloadKnownScope = async (): Promise<LynxComposerActionResult> => {
+    const api = requireApi();
+    if ('status' in api) return api;
+    if (!serverScope) return refreshServerScope();
+    const result = await fetchLynxMessageQueueScope(api.runtimeFetch, serverScope.scopeID, {
+      offset: 0,
+      limit: 8,
+    });
+    if (result.status !== 'ok') {
+      if (isLynxMessageQueueUnavailable(result)) {
+        useLocalQueue();
+        return { status: 'ok' };
+      }
+      return {
+        status: 'failed',
+        error: result.error,
+        reason: result.reason === 'invalid' ? 'invalid' : 'http',
+      };
+    }
+    applyServerScope(result.value);
+    return { status: 'ok' };
   };
 
   const promptQueuedItem = async (
@@ -97,6 +199,14 @@ export function createLynxComposerActions(
 
   return {
     getQueue: () => queue.slice(),
+    getQueueMode: () => queueMode,
+
+    refreshQueue: async () => {
+      const backend = await ensureQueueBackend();
+      if (typeof backend !== 'string') return backend;
+      if (backend === 'local') return { status: 'ok' };
+      return reloadKnownScope();
+    },
 
     send: async (text, options) => {
       const trimmed = text.trim();
@@ -146,10 +256,64 @@ export function createLynxComposerActions(
       if (!trimmed) {
         return { status: 'failed', error: 'empty prompt', reason: 'invalid' };
       }
-      // Queue is local until flush hits prompt_async. Still require a runtime
-      // so we never pretend a disconnected client can deliver later.
       const api = requireApi();
       if ('status' in api) return api;
+
+      const backend = await ensureQueueBackend();
+      if (typeof backend !== 'string') return backend;
+
+      if (backend === 'server') {
+        const id = createId();
+        const createdAt = now();
+        const admitted = await admitLynxTextQueueItem(api.runtimeFetch, {
+          requestID: `request-${id}`,
+          expectedRevision: serverScope?.revision,
+          scope: { directory: directory(), sessionID: input.sessionId },
+          item: {
+            queueItemID: id.startsWith('queued-') ? id : `queued-${id}`,
+            operationID: `operation-${id}`,
+            messageID: `msg_${id}`,
+            content: trimmed,
+            attachments: [],
+            attachmentIssues: [],
+            createdAt,
+            sendConfig: {
+              providerID: input.model.providerID,
+              modelID: input.model.modelID,
+              ...(input.model.agent ? { agent: input.model.agent } : {}),
+              ...(input.model.variant ? { variant: input.model.variant } : {}),
+            },
+          },
+        });
+        if (admitted.status !== 'ok') {
+          if (isLynxMessageQueueUnavailable(admitted)) {
+            useLocalQueue();
+            const localItem: LynxQueuedPrompt = { id, text: trimmed, createdAt };
+            queue.push(localItem);
+            return { status: 'ok', queuedId: localItem.id };
+          }
+          return {
+            status: 'failed',
+            error: admitted.error,
+            reason: admitted.reason === 'invalid' ? 'invalid' : 'http',
+          };
+        }
+        const queuedId = admitted.value.queueItemID ?? (id.startsWith('queued-') ? id : `queued-${id}`);
+        const refreshed = await reloadKnownScope();
+        if (refreshed.status !== 'ok') {
+          // Admission committed — surface id even if refresh races.
+          if (!queue.some((entry) => entry.id === queuedId)) {
+            queue.push({
+              id: queuedId,
+              text: trimmed,
+              createdAt,
+              rowVersion: admitted.value.rowVersion,
+            });
+          }
+        }
+        return { status: 'ok', queuedId };
+      }
+
       const item: LynxQueuedPrompt = {
         id: createId(),
         text: trimmed,
@@ -162,7 +326,7 @@ export function createLynxComposerActions(
     flushQueue: async () => {
       const api = requireApi();
       if ('status' in api) return api;
-      if (queue.length === 0) {
+      if (queue.length === 0 && !serverScope?.items.length) {
         return { status: 'failed', error: 'queue empty', reason: 'invalid' };
       }
       if (input.sessionIsWorking?.()) {
@@ -172,6 +336,32 @@ export function createLynxComposerActions(
           reason: 'busy-steer-required',
         };
       }
+
+      const backend = await ensureQueueBackend();
+      if (typeof backend !== 'string') return backend;
+
+      if (backend === 'server') {
+        if (!serverScope || serverScope.items.length === 0) {
+          const refreshed = await reloadKnownScope();
+          if (refreshed.status !== 'ok') return refreshed;
+        }
+        if (!serverScope || serverScope.items.length === 0) {
+          return { status: 'failed', error: 'queue empty', reason: 'invalid' };
+        }
+        const flushed = await flushLynxQueueScopeFirst(api.runtimeFetch, serverScope, {
+          requestID: `request-${createId()}`,
+        });
+        if (flushed.status !== 'ok') {
+          return {
+            status: 'failed',
+            error: flushed.error,
+            reason: flushed.reason === 'unavailable' ? 'unavailable' : flushed.reason === 'invalid' ? 'invalid' : 'http',
+          };
+        }
+        await reloadKnownScope();
+        return { status: 'ok', messageId: flushed.value.queueItemID };
+      }
+
       const next = queue[0]!;
       const sent = await promptQueuedItem(api, next);
       if (sent.status !== 'ok') return sent;
@@ -186,16 +376,45 @@ export function createLynxComposerActions(
       if (!id) {
         return { status: 'failed', error: 'queue item id required', reason: 'invalid' };
       }
-      const index = queue.findIndex((item) => item.id === id);
-      if (index < 0) {
-        return { status: 'failed', error: 'queue item not found', reason: 'invalid' };
-      }
       if (input.sessionIsWorking?.()) {
         return {
           status: 'failed',
           error: 'session still working — wait or stop before send-now',
           reason: 'busy-steer-required',
         };
+      }
+
+      const backend = await ensureQueueBackend();
+      if (typeof backend !== 'string') return backend;
+
+      if (backend === 'server') {
+        if (!serverScope) {
+          const refreshed = await reloadKnownScope();
+          if (refreshed.status !== 'ok') return refreshed;
+        }
+        const latest = serverScope?.items.find((entry) => entry.queueItemID === id);
+        if (!latest || !serverScope) {
+          return { status: 'failed', error: 'queue item not found', reason: 'invalid' };
+        }
+        const sent = await sendLynxQueueItemNow(api.runtimeFetch, id, {
+          requestID: `request-${createId()}`,
+          expectedRevision: serverScope.revision,
+          expectedRowVersion: latest.rowVersion,
+        });
+        if (sent.status !== 'ok') {
+          return {
+            status: 'failed',
+            error: sent.error,
+            reason: sent.reason === 'unavailable' ? 'unavailable' : sent.reason === 'invalid' ? 'invalid' : 'http',
+          };
+        }
+        await reloadKnownScope();
+        return { status: 'ok', messageId: sent.value.queueItemID ?? id };
+      }
+
+      const index = queue.findIndex((item) => item.id === id);
+      if (index < 0) {
+        return { status: 'failed', error: 'queue item not found', reason: 'invalid' };
       }
       const item = queue[index]!;
       const sent = await promptQueuedItem(api, item);
@@ -204,13 +423,42 @@ export function createLynxComposerActions(
       return sent;
     },
 
-    removeFromQueue: (queueItemId) => {
+    removeFromQueue: async (queueItemId) => {
       const api = requireApi();
       if ('status' in api) return api;
       const id = queueItemId.trim();
       if (!id) {
         return { status: 'failed', error: 'queue item id required', reason: 'invalid' };
       }
+
+      const backend = await ensureQueueBackend();
+      if (typeof backend !== 'string') return backend;
+
+      if (backend === 'server') {
+        if (!serverScope) {
+          const refreshed = await reloadKnownScope();
+          if (refreshed.status !== 'ok') return refreshed;
+        }
+        const latest = serverScope?.items.find((entry) => entry.queueItemID === id);
+        if (!latest || !serverScope) {
+          return { status: 'failed', error: 'queue item not found', reason: 'invalid' };
+        }
+        const removed = await removeLynxQueueItem(api.runtimeFetch, id, {
+          requestID: `request-${createId()}`,
+          expectedRevision: serverScope.revision,
+          expectedRowVersion: latest.rowVersion,
+        });
+        if (removed.status !== 'ok') {
+          return {
+            status: 'failed',
+            error: removed.error,
+            reason: removed.reason === 'unavailable' ? 'unavailable' : removed.reason === 'invalid' ? 'invalid' : 'http',
+          };
+        }
+        await reloadKnownScope();
+        return { status: 'ok' };
+      }
+
       const before = queue.length;
       queue = queue.filter((item) => item.id !== id);
       if (queue.length === before) {
@@ -219,17 +467,55 @@ export function createLynxComposerActions(
       return { status: 'ok' };
     },
 
-    reorderQueue: (activeId, overId) => {
+    reorderQueue: async (activeId, overId) => {
       const api = requireApi();
       if ('status' in api) return api;
       if (!activeId.trim() || !overId.trim()) {
         return { status: 'failed', error: 'reorder ids required', reason: 'invalid' };
       }
+
+      const backend = await ensureQueueBackend();
+      if (typeof backend !== 'string') return backend;
+
+      if (backend === 'server') {
+        if (!serverScope) {
+          const refreshed = await reloadKnownScope();
+          if (refreshed.status !== 'ok') return refreshed;
+        }
+        if (!serverScope) {
+          return { status: 'failed', error: 'server queue scope missing', reason: 'invalid' };
+        }
+        const asPrompts = lynxQueueItemsToPrompts(serverScope.items);
+        const next = reorderLynxQueueChips(asPrompts, activeId, overId);
+        const changed = next.length === asPrompts.length
+          && next.some((item, index) => item.id !== asPrompts[index]?.id);
+        if (!changed && activeId !== overId) {
+          const hasActive = asPrompts.some((item) => item.id === activeId);
+          const hasOver = asPrompts.some((item) => item.id === overId);
+          if (!hasActive || !hasOver) {
+            return { status: 'failed', error: 'reorder ids not in queue', reason: 'invalid' };
+          }
+        }
+        const reordered = await reorderLynxQueueScope(api.runtimeFetch, serverScope.scopeID, {
+          requestID: `request-${createId()}`,
+          expectedRevision: serverScope.revision,
+          queueItemIDs: next.map((item) => item.id),
+        });
+        if (reordered.status !== 'ok') {
+          return {
+            status: 'failed',
+            error: reordered.error,
+            reason: reordered.reason === 'unavailable' ? 'unavailable' : reordered.reason === 'invalid' ? 'invalid' : 'http',
+          };
+        }
+        await reloadKnownScope();
+        return { status: 'ok' };
+      }
+
       const next = reorderLynxQueueChips(queue, activeId, overId);
       const changed = next.length === queue.length
         && next.some((item, index) => item.id !== queue[index]?.id);
       if (!changed && activeId !== overId) {
-        // Ids missing — honest failure rather than silent no-op success.
         const hasActive = queue.some((item) => item.id === activeId);
         const hasOver = queue.some((item) => item.id === overId);
         if (!hasActive || !hasOver) {

--- a/packages/lynx/src/chat/composerActions.ts
+++ b/packages/lynx/src/chat/composerActions.ts
@@ -119,7 +119,7 @@ export function createLynxComposerActions(
     serverScope = null;
   };
 
-  const refreshServerScope = async (): Promise<LynxComposerActionResult> => {
+  const refreshServerScope = async (): Promise<'server' | 'local' | LynxComposerActionResult> => {
     const api = requireApi();
     if ('status' in api) return api;
     const result = await fetchLynxMessageQueueScopeForSession(api.runtimeFetch, {
@@ -129,7 +129,7 @@ export function createLynxComposerActions(
     if (result.status !== 'ok') {
       if (isLynxMessageQueueUnavailable(result)) {
         useLocalQueue();
-        return { status: 'ok' };
+        return 'local';
       }
       return {
         status: 'failed',
@@ -138,7 +138,7 @@ export function createLynxComposerActions(
       };
     }
     applyServerScope(result.value);
-    return { status: 'ok' };
+    return 'server';
   };
 
   const ensureQueueBackend = async (): Promise<'server' | 'local' | LynxComposerActionResult> => {
@@ -150,15 +150,17 @@ export function createLynxComposerActions(
     }
     if (queueMode === 'server') return 'server';
     if (queueMode === 'local') return 'local';
-    const probed = await refreshServerScope();
-    if (probed.status !== 'ok') return probed;
-    return queueMode === 'server' ? 'server' : 'local';
+    return refreshServerScope();
   };
 
   const reloadKnownScope = async (): Promise<LynxComposerActionResult> => {
     const api = requireApi();
     if ('status' in api) return api;
-    if (!serverScope) return refreshServerScope();
+    if (!serverScope) {
+      const probed = await refreshServerScope();
+      if (typeof probed === 'string') return { status: 'ok' };
+      return probed;
+    }
     const result = await fetchLynxMessageQueueScope(api.runtimeFetch, serverScope.scopeID, {
       offset: 0,
       limit: 8,

--- a/packages/lynx/src/chat/index.ts
+++ b/packages/lynx/src/chat/index.ts
@@ -218,6 +218,20 @@ export {
 } from './queuedMessageChips';
 export { LynxQueuedMessageChips } from './QueuedMessageChips';
 export {
+  LYNX_MESSAGE_QUEUE_ROUTE,
+  fetchLynxMessageQueueSnapshot,
+  fetchLynxMessageQueueScope,
+  fetchLynxMessageQueueScopeForSession,
+  admitLynxTextQueueItem,
+  reorderLynxQueueScope,
+  removeLynxQueueItem,
+  sendLynxQueueItemNow,
+  flushLynxQueueScopeFirst,
+  type LynxMessageQueueItem,
+  type LynxMessageQueueScope,
+  type LynxMessageQueueMutationResult,
+} from './messageQueueServer';
+export {
   parseLynxSessionGoal,
   formatLynxGoalTokens,
   formatLynxGoalDuration,

--- a/packages/lynx/src/chat/messageQueueServer.test.ts
+++ b/packages/lynx/src/chat/messageQueueServer.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from 'vitest';
+
+import type { LynxRuntimeFetch } from '../runtime/fetch';
+import {
+  admitLynxTextQueueItem,
+  fetchLynxMessageQueueScope,
+  fetchLynxMessageQueueScopeForSession,
+  flushLynxQueueScopeFirst,
+  isLynxMessageQueueUnavailable,
+  LYNX_MESSAGE_QUEUE_ROUTE,
+  removeLynxQueueItem,
+  reorderLynxQueueScope,
+  sendLynxQueueItemNow,
+} from './messageQueueServer';
+
+const item = {
+  queueItemID: 'item/a',
+  operationID: 'operation/a',
+  messageID: 'message/a',
+  content: 'hello',
+  status: 'queued',
+  attemptCount: 0,
+  position: 0,
+  rowVersion: 2,
+  createdAt: 1,
+};
+
+const scope = {
+  scopeID: 'scope/a',
+  revision: 4,
+  directory: '/repo',
+  sessionID: 'session/a',
+  worktreeState: 'active',
+  itemCount: 1,
+  items: [item],
+};
+
+const snapshot = {
+  revision: 4,
+  scopes: [{
+    scopeID: 'scope/a',
+    revision: 4,
+    directory: '/repo',
+    sessionID: 'session/a',
+    worktreeState: 'active',
+    itemCount: 1,
+  }],
+  worktreeOrders: [],
+};
+
+type Call = { method: string; path: string; body?: string };
+
+const mockFetch = (
+  impl: (call: Call) => { ok: boolean; status: number; json: () => Promise<unknown> },
+): { runtimeFetch: LynxRuntimeFetch; calls: Call[] } => {
+  const calls: Call[] = [];
+  const runtimeFetch: LynxRuntimeFetch = async (path, init) => {
+    const call: Call = {
+      method: init?.method ?? 'GET',
+      path,
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    };
+    calls.push(call);
+    return impl(call);
+  };
+  return { runtimeFetch, calls };
+};
+
+describe('Lynx messageQueueServer Cap client', () => {
+  test('happy path: list scope for session + admit + reorder + remove + send-now + flush', async () => {
+    const { runtimeFetch, calls } = mockFetch((call) => {
+      if (call.method === 'GET' && call.path === LYNX_MESSAGE_QUEUE_ROUTE) {
+        return { ok: true, status: 200, json: async () => snapshot };
+      }
+      if (call.method === 'GET' && call.path.includes('/scopes/')) {
+        return { ok: true, status: 200, json: async () => scope };
+      }
+      if (call.method === 'POST' && call.path.endsWith('/items')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            revision: 5,
+            scopeID: 'scope/a',
+            queueItemID: 'item/a',
+            rowVersion: 2,
+          }),
+        };
+      }
+      if (call.method === 'PUT' && call.path.includes('/order')) {
+        return { ok: true, status: 200, json: async () => ({ revision: 6, scopeID: 'scope/a' }) };
+      }
+      if (call.method === 'DELETE' && call.path.includes('/items/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ revision: 7, removedQueueItemID: 'item/a' }),
+        };
+      }
+      if (call.method === 'POST' && call.path.includes('/send')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ revision: 8, queueItemID: 'item/a', rowVersion: 3 }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    const listed = await fetchLynxMessageQueueScopeForSession(runtimeFetch, {
+      directory: '/repo',
+      sessionID: 'session/a',
+    });
+    expect(listed).toMatchObject({ status: 'ok', value: { scopeID: 'scope/a', revision: 4 } });
+    expect(listed.status === 'ok' && listed.value?.items[0]?.content).toBe('hello');
+
+    const admitted = await admitLynxTextQueueItem(runtimeFetch, {
+      requestID: 'r1',
+      expectedRevision: 4,
+      scope: { directory: '/repo', sessionID: 'session/a' },
+      item: {
+        queueItemID: 'item/a',
+        operationID: 'operation/a',
+        messageID: 'message/a',
+        content: 'hello',
+        attachments: [],
+        attachmentIssues: [],
+        createdAt: 1,
+      },
+    });
+    expect(admitted).toMatchObject({
+      status: 'ok',
+      value: { revision: 5, scopeID: 'scope/a', queueItemID: 'item/a' },
+    });
+
+    const reordered = await reorderLynxQueueScope(runtimeFetch, 'scope/a', {
+      requestID: 'r2',
+      expectedRevision: 5,
+      queueItemIDs: ['item/a'],
+    });
+    expect(reordered).toMatchObject({ status: 'ok', value: { revision: 6 } });
+
+    const removed = await removeLynxQueueItem(runtimeFetch, 'item/a', {
+      requestID: 'r3',
+      expectedRevision: 6,
+      expectedRowVersion: 2,
+    });
+    expect(removed).toMatchObject({
+      status: 'ok',
+      value: { revision: 7, removedQueueItemID: 'item/a' },
+    });
+
+    const sent = await sendLynxQueueItemNow(runtimeFetch, 'item/a', {
+      requestID: 'r4',
+      expectedRevision: 7,
+      expectedRowVersion: 2,
+    });
+    expect(sent).toMatchObject({ status: 'ok', value: { revision: 8, queueItemID: 'item/a' } });
+
+    const flushed = await flushLynxQueueScopeFirst(runtimeFetch, scope, { requestID: 'r5' });
+    expect(flushed).toMatchObject({ status: 'ok', value: { revision: 8 } });
+
+    expect(calls.some((c) => c.path.includes('/scopes/scope%2Fa') || c.path.includes('/scopes/scope/a'))).toBe(true);
+    expect(calls.some((c) => c.method === 'POST' && c.path.endsWith('/items'))).toBe(true);
+    expect(calls.some((c) => c.method === 'PUT' && c.path.includes('/order'))).toBe(true);
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(true);
+    expect(calls.filter((c) => c.path.includes('/send')).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('failure paths: no-runtime, HTTP error code, malformed success, empty session', async () => {
+    expect(await fetchLynxMessageQueueScope(null, 'scope/a')).toMatchObject({
+      status: 'failed',
+      reason: 'unavailable',
+      code: 'unavailable',
+    });
+
+    const { runtimeFetch: httpFetch } = mockFetch(() => ({
+      ok: false,
+      status: 409,
+      json: async () => ({ code: 'revision_conflict' }),
+    }));
+    const conflict = await reorderLynxQueueScope(httpFetch, 'scope/a', {
+      requestID: 'r',
+      expectedRevision: 1,
+      queueItemIDs: ['a'],
+    });
+    expect(conflict).toMatchObject({
+      status: 'failed',
+      reason: 'http',
+      code: 'revision_conflict',
+      httpStatus: 409,
+    });
+    expect(isLynxMessageQueueUnavailable(conflict as Extract<typeof conflict, { status: 'failed' }>)).toBe(false);
+
+    const { runtimeFetch: badFetch } = mockFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ revision: 1, unexpected: true }),
+    }));
+    const malformed = await admitLynxTextQueueItem(badFetch, {
+      requestID: 'r',
+      scope: { directory: '/repo', sessionID: 'ses' },
+      item: {
+        queueItemID: 'q',
+        operationID: 'o',
+        messageID: 'm',
+        content: 'x',
+        attachments: [],
+        attachmentIssues: [],
+        createdAt: 1,
+      },
+    });
+    expect(malformed).toMatchObject({ status: 'failed', reason: 'unavailable', code: 'unavailable' });
+
+    const { runtimeFetch: status501 } = mockFetch(() => ({
+      ok: false,
+      status: 501,
+      json: async () => ({ code: 'unavailable' }),
+    }));
+    const unavailable = await fetchLynxMessageQueueScope(status501, 'scope/a');
+    expect(unavailable).toMatchObject({ status: 'failed', reason: 'unavailable' });
+    expect(isLynxMessageQueueUnavailable(unavailable as Extract<typeof unavailable, { status: 'failed' }>)).toBe(true);
+
+    expect(await fetchLynxMessageQueueScopeForSession(status501, {
+      directory: '/repo',
+      sessionID: '  ',
+    })).toMatchObject({ status: 'failed', reason: 'invalid' });
+
+    const { runtimeFetch: malformedScope } = mockFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ ...scope, items: [{ ...item, queueItemID: 1 }] }),
+    }));
+    expect(await fetchLynxMessageQueueScope(malformedScope, 'scope/a')).toMatchObject({
+      status: 'failed',
+      reason: 'unavailable',
+    });
+  });
+
+  test('encodes scope id and posts Cap mutation bodies', async () => {
+    const { runtimeFetch, calls } = mockFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ revision: 1, scopeID: 'scope/a?' }),
+    }));
+    await fetchLynxMessageQueueScope(runtimeFetch, 'scope/a?', {
+      offset: 2,
+      limit: 8,
+      expectedRevision: 4,
+    });
+    await reorderLynxQueueScope(runtimeFetch, 'scope/a?', {
+      requestID: 'r4',
+      expectedRevision: 5,
+      queueItemIDs: ['item/a', 'item/b'],
+    });
+    expect(calls[0]?.path).toContain('/scopes/scope%2Fa%3F');
+    expect(calls[0]?.path).toContain('offset=2');
+    expect(calls[0]?.path).toContain('expectedRevision=4');
+    expect(JSON.parse(calls[1]?.body ?? '{}')).toEqual({
+      requestID: 'r4',
+      expectedRevision: 5,
+      queueItemIDs: ['item/a', 'item/b'],
+    });
+  });
+});

--- a/packages/lynx/src/chat/messageQueueServer.ts
+++ b/packages/lynx/src/chat/messageQueueServer.ts
@@ -1,0 +1,588 @@
+/**
+ * Cap `/api/openchamber/message-queue` thin portable client for Lynx.
+ *
+ * Ports list/admit/reorder/remove/send-now (+ flush = send-now first) over
+ * LynxRuntimeFetch — no Zustand / TanStack / @dnd-kit. Honest parse; HTTP /
+ * no-runtime never fake-success.
+ */
+import type { LynxRuntimeFetch } from '../runtime/fetch';
+import type { LynxHttpResponse, LynxRequestInit } from '../connection/types';
+
+export const LYNX_MESSAGE_QUEUE_ROUTE = '/api/openchamber/message-queue';
+
+export type LynxMessageQueueServerErrorCode =
+  | 'validation_error'
+  | 'revision_conflict'
+  | 'row_version_conflict'
+  | 'idempotency_conflict'
+  | 'generation_conflict'
+  | 'authority_conflict'
+  | 'not_found'
+  | 'scope_locked'
+  | 'scope_limit'
+  | 'reserved'
+  | 'internal_error'
+  | 'unavailable';
+
+export class LynxMessageQueueServerError extends Error {
+  readonly status: number;
+  readonly code: LynxMessageQueueServerErrorCode;
+
+  constructor(status: number, code: LynxMessageQueueServerErrorCode) {
+    super(`Message queue server request failed: ${code}`);
+    this.name = 'LynxMessageQueueServerError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export type LynxMessageQueueItem = {
+  queueItemID: string;
+  operationID: string;
+  messageID: string;
+  content: string;
+  status: string;
+  attemptCount: number;
+  position: number;
+  rowVersion: number;
+  createdAt: number;
+  manualDispatchRequested?: boolean;
+};
+
+export type LynxMessageQueueScope = {
+  scopeID: string;
+  revision: number;
+  directory: string;
+  sessionID: string;
+  worktreeState: string;
+  items: LynxMessageQueueItem[];
+  itemCount: number;
+  nextOffset?: number;
+};
+
+export type LynxMessageQueueScopeDescriptor = {
+  scopeID: string;
+  revision: number;
+  directory: string;
+  sessionID: string;
+  worktreeState: string;
+  itemCount: number;
+};
+
+export type LynxMessageQueueSnapshot = {
+  revision: number;
+  scopes: LynxMessageQueueScopeDescriptor[];
+};
+
+export type LynxMessageQueueMutationResult = {
+  revision: number;
+  scopeID?: string;
+  queueItemID?: string;
+  rowVersion?: number;
+  removedQueueItemID?: string;
+};
+
+export type LynxMessageQueueAdmissionItem = {
+  queueItemID: string;
+  operationID: string;
+  messageID: string;
+  content: string;
+  attachments: [];
+  attachmentIssues: [];
+  createdAt: number;
+  sendConfig?: {
+    providerID: string;
+    modelID: string;
+    agent?: string;
+    variant?: string;
+  };
+};
+
+export type LynxMessageQueueResult<T> =
+  | { status: 'ok'; value: T }
+  | {
+    status: 'failed';
+    error: string;
+    reason: 'no-runtime' | 'http' | 'unavailable' | 'invalid';
+    code?: LynxMessageQueueServerErrorCode;
+    httpStatus?: number;
+  };
+
+const ERROR_CODES = new Set<LynxMessageQueueServerErrorCode>([
+  'validation_error',
+  'revision_conflict',
+  'row_version_conflict',
+  'idempotency_conflict',
+  'generation_conflict',
+  'authority_conflict',
+  'not_found',
+  'scope_locked',
+  'scope_limit',
+  'reserved',
+  'internal_error',
+  'unavailable',
+]);
+
+const MUTATION_KEYS = new Set([
+  'revision',
+  'scopeID',
+  'queueItemID',
+  'rowVersion',
+  'removedQueueItemID',
+  'projectDirectory',
+  'token',
+  'state',
+  'scopeCount',
+  'statusCounts',
+]);
+
+const SCOPE_DESCRIPTOR_KEYS = new Set([
+  'scopeID',
+  'revision',
+  'directory',
+  'sessionID',
+  'worktreeState',
+  'itemCount',
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const isRevision = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+
+const joinQuery = (params: Record<string, string | number | undefined>): string => {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  }
+  return parts.length > 0 ? `?${parts.join('&')}` : '';
+};
+
+const parseErrorCode = async (
+  response: LynxHttpResponse,
+): Promise<LynxMessageQueueServerErrorCode> => {
+  if (response.status === 501) return 'unavailable';
+  try {
+    const payload: unknown = await response.json();
+    if (
+      isRecord(payload)
+      && typeof payload.code === 'string'
+      && ERROR_CODES.has(payload.code as LynxMessageQueueServerErrorCode)
+    ) {
+      return payload.code as LynxMessageQueueServerErrorCode;
+    }
+  } catch {
+    // Stable errors deliberately omit untrusted response content.
+  }
+  return 'unavailable';
+};
+
+const toFailed = (
+  error: unknown,
+): Extract<LynxMessageQueueResult<never>, { status: 'failed' }> => {
+  if (error instanceof LynxMessageQueueServerError) {
+    const reason = error.code === 'unavailable' && (error.status === 0 || error.status === 501)
+      ? 'unavailable'
+      : error.code === 'unavailable'
+        ? 'unavailable'
+        : 'http';
+    return {
+      status: 'failed',
+      error: error.message,
+      reason,
+      code: error.code,
+      httpStatus: error.status,
+    };
+  }
+  return {
+    status: 'failed',
+    error: error instanceof Error ? error.message : 'message-queue request failed',
+    reason: 'http',
+  };
+};
+
+const requestJson = async (
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  path: string,
+  init?: LynxRequestInit,
+): Promise<unknown> => {
+  if (!runtimeFetch) {
+    throw new LynxMessageQueueServerError(0, 'unavailable');
+  }
+  let response: LynxHttpResponse;
+  try {
+    response = await runtimeFetch(path, init);
+  } catch {
+    throw new LynxMessageQueueServerError(0, 'unavailable');
+  }
+  if (response.status === 0 && !response.ok) {
+    throw new LynxMessageQueueServerError(0, 'unavailable');
+  }
+  if (!response.ok) {
+    throw new LynxMessageQueueServerError(response.status, await parseErrorCode(response));
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new LynxMessageQueueServerError(response.status, 'unavailable');
+  }
+};
+
+const malformed = (): never => {
+  throw new LynxMessageQueueServerError(200, 'unavailable');
+};
+
+const parseItem = (value: unknown): LynxMessageQueueItem | null => {
+  if (
+    !isRecord(value)
+    || typeof value.queueItemID !== 'string'
+    || typeof value.operationID !== 'string'
+    || typeof value.messageID !== 'string'
+    || typeof value.content !== 'string'
+    || typeof value.status !== 'string'
+    || !isRevision(value.attemptCount)
+    || !isRevision(value.position)
+    || !isRevision(value.rowVersion)
+    || !isRevision(value.createdAt)
+  ) {
+    return null;
+  }
+  if (value.manualDispatchRequested !== undefined && typeof value.manualDispatchRequested !== 'boolean') {
+    return null;
+  }
+  return {
+    queueItemID: value.queueItemID,
+    operationID: value.operationID,
+    messageID: value.messageID,
+    content: value.content,
+    status: value.status,
+    attemptCount: value.attemptCount,
+    position: value.position,
+    rowVersion: value.rowVersion,
+    createdAt: value.createdAt,
+    ...(value.manualDispatchRequested === true ? { manualDispatchRequested: true } : {}),
+  };
+};
+
+const parseScope = (value: unknown): LynxMessageQueueScope | null => {
+  if (
+    !isRecord(value)
+    || typeof value.scopeID !== 'string'
+    || !isRevision(value.revision)
+    || typeof value.directory !== 'string'
+    || typeof value.sessionID !== 'string'
+    || typeof value.worktreeState !== 'string'
+    || !isRevision(value.itemCount)
+    || !Array.isArray(value.items)
+    || value.items.length > 8
+    || (
+      value.nextOffset !== undefined
+      && (!isRevision(value.nextOffset) || value.nextOffset <= 0)
+    )
+  ) {
+    return null;
+  }
+  const items = value.items.map(parseItem);
+  if (!items.every((item): item is LynxMessageQueueItem => item !== null)) return null;
+  return {
+    scopeID: value.scopeID,
+    revision: value.revision,
+    directory: value.directory,
+    sessionID: value.sessionID,
+    worktreeState: value.worktreeState,
+    itemCount: value.itemCount,
+    items,
+    ...(value.nextOffset === undefined ? {} : { nextOffset: value.nextOffset }),
+  };
+};
+
+const parseScopeDescriptor = (value: unknown): LynxMessageQueueScopeDescriptor | null => (
+  isRecord(value)
+  && Object.keys(value).every((key) => SCOPE_DESCRIPTOR_KEYS.has(key))
+  && typeof value.scopeID === 'string'
+  && isRevision(value.revision)
+  && typeof value.directory === 'string'
+  && typeof value.sessionID === 'string'
+  && typeof value.worktreeState === 'string'
+  && isRevision(value.itemCount)
+    ? {
+      scopeID: value.scopeID,
+      revision: value.revision,
+      directory: value.directory,
+      sessionID: value.sessionID,
+      worktreeState: value.worktreeState,
+      itemCount: value.itemCount,
+    }
+    : null
+);
+
+const parseSnapshot = (value: unknown): LynxMessageQueueSnapshot => {
+  if (!isRecord(value) || !isRevision(value.revision) || !Array.isArray(value.scopes)) {
+    return malformed();
+  }
+  const scopes = value.scopes.map(parseScopeDescriptor);
+  if (!scopes.every((scope): scope is LynxMessageQueueScopeDescriptor => scope !== null)) {
+    return malformed();
+  }
+  return { revision: value.revision, scopes };
+};
+
+const parseMutation = (value: unknown): LynxMessageQueueMutationResult => {
+  if (!isRecord(value) || !isRevision(value.revision) || Object.keys(value).some((key) => !MUTATION_KEYS.has(key))) {
+    return malformed();
+  }
+  if (
+    (value.scopeID !== undefined && typeof value.scopeID !== 'string')
+    || (value.queueItemID !== undefined && typeof value.queueItemID !== 'string')
+    || (value.rowVersion !== undefined && !isRevision(value.rowVersion))
+    || (value.removedQueueItemID !== undefined && typeof value.removedQueueItemID !== 'string')
+  ) {
+    return malformed();
+  }
+  return {
+    revision: value.revision,
+    ...(typeof value.scopeID === 'string' ? { scopeID: value.scopeID } : {}),
+    ...(typeof value.queueItemID === 'string' ? { queueItemID: value.queueItemID } : {}),
+    ...(isRevision(value.rowVersion) ? { rowVersion: value.rowVersion } : {}),
+    ...(typeof value.removedQueueItemID === 'string'
+      ? { removedQueueItemID: value.removedQueueItemID }
+      : {}),
+  };
+};
+
+const jsonInit = (method: string, body: object, signal?: AbortSignal): LynxRequestInit => ({
+  method,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+  signal,
+});
+
+const normalizeDirectory = (value: string): string => value.replace(/\/+$/, '') || '/';
+
+/** Cap GET snapshot — scope descriptors for directory+session lookup. */
+export async function fetchLynxMessageQueueSnapshot(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  options: { signal?: AbortSignal } = {},
+): Promise<LynxMessageQueueResult<LynxMessageQueueSnapshot>> {
+  try {
+    const value = parseSnapshot(await requestJson(runtimeFetch, LYNX_MESSAGE_QUEUE_ROUTE, {
+      signal: options.signal,
+    }));
+    return { status: 'ok', value };
+  } catch (error) {
+    return toFailed(error);
+  }
+}
+
+/** Cap GET `/scopes/:scopeID` with offset/limit/expectedRevision. */
+export async function fetchLynxMessageQueueScope(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  scopeID: string,
+  options: {
+    offset?: number;
+    limit?: number;
+    expectedRevision?: number;
+    signal?: AbortSignal;
+  } = {},
+): Promise<LynxMessageQueueResult<LynxMessageQueueScope>> {
+  const id = scopeID.trim();
+  if (!id) {
+    return { status: 'failed', error: 'scope id required', reason: 'invalid' };
+  }
+  try {
+    const query = joinQuery({
+      offset: options.offset,
+      limit: options.limit,
+      expectedRevision: options.expectedRevision,
+    });
+    const value = parseScope(await requestJson(
+      runtimeFetch,
+      `${LYNX_MESSAGE_QUEUE_ROUTE}/scopes/${encodeURIComponent(id)}${query}`,
+      { signal: options.signal },
+    ));
+    if (!value) return toFailed(new LynxMessageQueueServerError(200, 'unavailable'));
+    return { status: 'ok', value };
+  } catch (error) {
+    return toFailed(error);
+  }
+}
+
+/**
+ * List/get scope for a directory+session: snapshot → matching descriptor → scope page.
+ * Empty ok when no scope yet (admit will create).
+ */
+export async function fetchLynxMessageQueueScopeForSession(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  input: { directory: string; sessionID: string; signal?: AbortSignal },
+): Promise<LynxMessageQueueResult<LynxMessageQueueScope | null>> {
+  const sessionID = input.sessionID.trim();
+  const directory = input.directory.trim();
+  if (!sessionID) {
+    return { status: 'failed', error: 'session id required', reason: 'invalid' };
+  }
+  const snapshot = await fetchLynxMessageQueueSnapshot(runtimeFetch, { signal: input.signal });
+  if (snapshot.status !== 'ok') return snapshot;
+  const dirKey = normalizeDirectory(directory || '/');
+  const descriptor = snapshot.value.scopes.find((scope) => (
+    scope.sessionID === sessionID
+    && normalizeDirectory(scope.directory) === dirKey
+  ));
+  if (!descriptor) return { status: 'ok', value: null };
+  return fetchLynxMessageQueueScope(runtimeFetch, descriptor.scopeID, {
+    offset: 0,
+    limit: 8,
+    expectedRevision: descriptor.revision,
+    signal: input.signal,
+  });
+}
+
+/** Cap POST `/items` text admit. */
+export async function admitLynxTextQueueItem(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  input: {
+    requestID: string;
+    expectedRevision?: number;
+    scope: { directory: string; sessionID: string };
+    item: LynxMessageQueueAdmissionItem;
+    signal?: AbortSignal;
+  },
+): Promise<LynxMessageQueueResult<LynxMessageQueueMutationResult>> {
+  if (!input.requestID.trim() || !input.scope.sessionID.trim() || !input.item.content.trim()) {
+    return { status: 'failed', error: 'admit requires requestID, sessionID, content', reason: 'invalid' };
+  }
+  try {
+    const { signal, ...body } = input;
+    const value = parseMutation(await requestJson(
+      runtimeFetch,
+      `${LYNX_MESSAGE_QUEUE_ROUTE}/items`,
+      jsonInit('POST', body, signal),
+    ));
+    return { status: 'ok', value };
+  } catch (error) {
+    return toFailed(error);
+  }
+}
+
+/** Cap PUT `/scopes/:scopeID/order` — portable ↑/↓ via queueItemIDs. */
+export async function reorderLynxQueueScope(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  scopeID: string,
+  input: {
+    requestID: string;
+    expectedRevision: number;
+    queueItemIDs: string[];
+    signal?: AbortSignal;
+  },
+): Promise<LynxMessageQueueResult<LynxMessageQueueMutationResult>> {
+  const id = scopeID.trim();
+  if (!id || !input.requestID.trim() || !Array.isArray(input.queueItemIDs)) {
+    return { status: 'failed', error: 'reorder requires scopeID, requestID, queueItemIDs', reason: 'invalid' };
+  }
+  try {
+    const { signal, ...body } = input;
+    const value = parseMutation(await requestJson(
+      runtimeFetch,
+      `${LYNX_MESSAGE_QUEUE_ROUTE}/scopes/${encodeURIComponent(id)}/order`,
+      jsonInit('PUT', body, signal),
+    ));
+    return { status: 'ok', value };
+  } catch (error) {
+    return toFailed(error);
+  }
+}
+
+/** Cap DELETE `/items/:queueItemID`. */
+export async function removeLynxQueueItem(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  queueItemID: string,
+  input: {
+    requestID: string;
+    expectedRevision: number;
+    expectedRowVersion: number;
+    signal?: AbortSignal;
+  },
+): Promise<LynxMessageQueueResult<LynxMessageQueueMutationResult>> {
+  const id = queueItemID.trim();
+  if (!id || !input.requestID.trim()) {
+    return { status: 'failed', error: 'remove requires queueItemID, requestID', reason: 'invalid' };
+  }
+  try {
+    const { signal, ...body } = input;
+    const value = parseMutation(await requestJson(
+      runtimeFetch,
+      `${LYNX_MESSAGE_QUEUE_ROUTE}/items/${encodeURIComponent(id)}`,
+      jsonInit('DELETE', body, signal),
+    ));
+    return { status: 'ok', value };
+  } catch (error) {
+    return toFailed(error);
+  }
+}
+
+/** Cap POST `/items/:queueItemID/send` (manual send-now). */
+export async function sendLynxQueueItemNow(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  queueItemID: string,
+  input: {
+    requestID: string;
+    expectedRevision: number;
+    expectedRowVersion: number;
+    signal?: AbortSignal;
+  },
+): Promise<LynxMessageQueueResult<LynxMessageQueueMutationResult>> {
+  const id = queueItemID.trim();
+  if (!id || !input.requestID.trim()) {
+    return { status: 'failed', error: 'send-now requires queueItemID, requestID', reason: 'invalid' };
+  }
+  try {
+    const { signal, ...body } = input;
+    const value = parseMutation(await requestJson(
+      runtimeFetch,
+      `${LYNX_MESSAGE_QUEUE_ROUTE}/items/${encodeURIComponent(id)}/send`,
+      jsonInit('POST', body, signal),
+    ));
+    return { status: 'ok', value };
+  } catch (error) {
+    return toFailed(error);
+  }
+}
+
+/** Flush maps to Cap send-now on the first queued item (no dedicated flush route). */
+export async function flushLynxQueueScopeFirst(
+  runtimeFetch: LynxRuntimeFetch | null | undefined,
+  scope: LynxMessageQueueScope,
+  input: { requestID: string; signal?: AbortSignal },
+): Promise<LynxMessageQueueResult<LynxMessageQueueMutationResult>> {
+  const first = scope.items[0];
+  if (!first) {
+    return { status: 'failed', error: 'queue empty', reason: 'invalid' };
+  }
+  return sendLynxQueueItemNow(runtimeFetch, first.queueItemID, {
+    requestID: input.requestID,
+    expectedRevision: scope.revision,
+    expectedRowVersion: first.rowVersion,
+    signal: input.signal,
+  });
+}
+
+export function lynxQueueItemsToPrompts(
+  items: readonly LynxMessageQueueItem[],
+): Array<{ id: string; text: string; createdAt: number; rowVersion: number }> {
+  return items.map((item) => ({
+    id: item.queueItemID,
+    text: item.content,
+    createdAt: item.createdAt,
+    rowVersion: item.rowVersion,
+  }));
+}
+
+export function isLynxMessageQueueUnavailable(
+  result: Extract<LynxMessageQueueResult<unknown>, { status: 'failed' }>,
+): boolean {
+  return result.reason === 'unavailable'
+    || result.code === 'unavailable'
+    || result.httpStatus === 501
+    || result.httpStatus === 0;
+}

--- a/packages/lynx/src/chat/queuedMessageChips.ts
+++ b/packages/lynx/src/chat/queuedMessageChips.ts
@@ -1,10 +1,9 @@
 /**
- * Cap QueuedMessageChips helpers for Lynx — local composerActions queue.
+ * Cap QueuedMessageChips helpers for Lynx — composerActions queue chips.
  *
- * Cap also has server `/api/openchamber/message-queue` + DnD-kit reorder.
- * Lynx uses the existing local queue (composerActions) and portable up/down
- * reorder (no @dnd-kit). Server message-queue is deferred until a Lynx
- * runtime path exists — do not invent TanStack mutation flights here.
+ * Prefer Cap server `/api/openchamber/message-queue` via messageQueueServer
+ * when runtimeFetch can reach it; otherwise local composerActions queue.
+ * Portable ↑/↓ reorder (no @dnd-kit / no TanStack mutation flights).
  */
 import type { LynxQueuedPrompt } from './composerActions';
 


### PR DESCRIPTION
## Summary
- Add thin Cap-compatible `packages/lynx/src/chat/messageQueueServer.ts` over `LynxRuntimeFetch`: list/get scope (directory+session), admit text, reorder by `queueItemIDs`, remove, send-now, flush→send-now first; honest parse; no-runtime/HTTP never fake-success.
- Wire `composerActions` + QueuedMessageChips: prefer Cap `/api/openchamber/message-queue` when reachable; fall back to local queue on unavailable (501/transport); portable ↑/↓ (no `@dnd-kit` / no TanStack).
- Vitest happy-path + failure coverage; gap-board/acceptance honesty for tip `c02f917f` / APK `lynx-v2-debug-c02f917` (Next #41 代码接上; product NOT DONE / 三关未齐 / 真机残差 empty).

## Test plan
- [x] `npx vitest run src/chat/messageQueueServer.test.ts src/chat/composerActions.test.ts` (8 passed)
- [ ] lynx-ci on PR
- [ ] Do not claim 真机过