### PR TITLE
fix(lynx): bound auto-connect splash so Connect welcome appears

### DIFF
--- a/packages/lynx/src/App.tsx
+++ b/packages/lynx/src/App.tsx
@@ -11,8 +11,11 @@ import {
 import type { LynxPendingConnection, LynxSavedConnection } from './connection/types';
 import { ConnectWelcome } from './connect/ConnectWelcome';
 import {
+  initialAutoConnectPhase,
   nextAutoConnectPhase,
+  raceAutoConnectAttempt,
   resolveLynxConnectGate,
+  shouldAttemptAutoConnect,
   type LynxAutoConnectPhase,
 } from './connect/autoConnectPhase';
 import { createHostGlobalProps, type LynxHostGlobalProps } from './host/embedding';
@@ -84,7 +87,13 @@ export function App({
     });
   }, [injectedClient]);
 
-  const [phase, setPhase] = useState<LynxAutoConnectPhase>(skipAutoConnect ? 'done' : 'pending');
+  const hasSavedToken = useMemo(
+    () => client.loadConnections().some((connection) => Boolean(connection.hasToken)),
+    [client],
+  );
+  const [phase, setPhase] = useState<LynxAutoConnectPhase>(() =>
+    initialAutoConnectPhase({ skipAutoConnect, hasSavedToken }),
+  );
   const [connected, setConnected] = useState(false);
   const [connections, setConnections] = useState<LynxSavedConnection[]>(() => client.loadConnections());
   const [pending, setPending] = useState<LynxPendingConnection | null>(null);
@@ -92,14 +101,18 @@ export function App({
   const [autoConnectLabel, setAutoConnectLabel] = useState<string | null>(null);
 
   useEffect(() => {
-    if (skipAutoConnect) return;
+    if (!shouldAttemptAutoConnect({ skipAutoConnect, hasSavedToken })) {
+      setPhase('done');
+      return;
+    }
     let cancelled = false;
     setPhase((current) => nextAutoConnectPhase(current, 'start'));
-    const target = client.loadConnections()[0];
+    const target = client.loadConnections().find((connection) => Boolean(connection.hasToken))
+      ?? client.loadConnections()[0];
     setAutoConnectLabel(target?.label ?? null);
     void (async () => {
       try {
-        const ok = await client.autoConnectLastInstance();
+        const ok = await raceAutoConnectAttempt(client.autoConnectLastInstance());
         if (cancelled) return;
         if (ok) {
           setConnected(true);
@@ -112,7 +125,7 @@ export function App({
     return () => {
       cancelled = true;
     };
-  }, [client, skipAutoConnect]);
+  }, [client, hasSavedToken, skipAutoConnect]);
 
   const gate = resolveLynxConnectGate({ phase, connected, autoConnectLabel });
 

--- a/packages/lynx/src/connect/autoConnectPhase.test.ts
+++ b/packages/lynx/src/connect/autoConnectPhase.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
-import { nextAutoConnectPhase, resolveLynxConnectGate } from './autoConnectPhase';
+import {
+  AUTO_CONNECT_ATTEMPT_TIMEOUT_MS,
+  initialAutoConnectPhase,
+  nextAutoConnectPhase,
+  raceAutoConnectAttempt,
+  resolveLynxConnectGate,
+  shouldAttemptAutoConnect,
+} from './autoConnectPhase';
 
 describe('Lynx auto-connect gate', () => {
   test('splash while attempting, welcome when done unconnected', () => {
@@ -25,5 +32,40 @@ describe('Lynx auto-connect gate', () => {
     expect(nextAutoConnectPhase('pending', 'start')).toBe('attempting');
     expect(nextAutoConnectPhase('attempting', 'finish')).toBe('done');
     expect(nextAutoConnectPhase('done', 'start')).toBe('done');
+  });
+
+  test('initial phase skips splash without saved token or when skipAutoConnect', () => {
+    expect(initialAutoConnectPhase({ skipAutoConnect: true, hasSavedToken: true })).toBe('done');
+    expect(initialAutoConnectPhase({ skipAutoConnect: false, hasSavedToken: false })).toBe('done');
+    expect(initialAutoConnectPhase({ skipAutoConnect: false, hasSavedToken: true })).toBe('pending');
+  });
+
+  test('shouldAttemptAutoConnect only when token exists and not skipped', () => {
+    expect(shouldAttemptAutoConnect({ skipAutoConnect: true, hasSavedToken: true })).toBe(false);
+    expect(shouldAttemptAutoConnect({ skipAutoConnect: false, hasSavedToken: false })).toBe(false);
+    expect(shouldAttemptAutoConnect({ skipAutoConnect: false, hasSavedToken: true })).toBe(true);
+  });
+
+  test('raceAutoConnectAttempt returns success before timeout', async () => {
+    await expect(raceAutoConnectAttempt(Promise.resolve(true), 50)).resolves.toBe(true);
+    await expect(raceAutoConnectAttempt(Promise.resolve(false), 50)).resolves.toBe(false);
+  });
+
+  test('raceAutoConnectAttempt times out hanging attempt → false (welcome path)', async () => {
+    vi.useFakeTimers();
+    try {
+      const hanging = new Promise<boolean>(() => {});
+      const raced = raceAutoConnectAttempt(hanging, AUTO_CONNECT_ATTEMPT_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(AUTO_CONNECT_ATTEMPT_TIMEOUT_MS);
+      await expect(raced).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('raceAutoConnectAttempt treats reject as false', async () => {
+    await expect(
+      raceAutoConnectAttempt(Promise.reject(new Error('probe-failed')), 50),
+    ).resolves.toBe(false);
   });
 });

--- a/packages/lynx/src/connect/autoConnectPhase.ts
+++ b/packages/lynx/src/connect/autoConnectPhase.ts
@@ -1,9 +1,14 @@
+import { raceWithTimeout } from '../connection/http';
+
 export type LynxAutoConnectPhase = 'pending' | 'attempting' | 'done';
 
 export type LynxConnectGate =
   | { kind: 'splash'; phase: Exclude<LynxAutoConnectPhase, 'done'>; label: string | null }
   | { kind: 'welcome' }
   | { kind: 'connected' };
+
+/** Cap-like bound so a hanging probe cannot keep the splash forever. */
+export const AUTO_CONNECT_ATTEMPT_TIMEOUT_MS = 2500;
 
 /**
  * Cap MobileApp auto-connect gate:
@@ -34,4 +39,39 @@ export function nextAutoConnectPhase(
   if (event === 'start' && current === 'pending') return 'attempting';
   if (event === 'finish') return 'done';
   return current;
+}
+
+/**
+ * Initial gate phase. Skip splash when auto-connect is disabled or there is no
+ * saved token to attempt — otherwise a Lynx useEffect that never settles leaves
+ * the user forever on "Connecting…".
+ */
+export function initialAutoConnectPhase(input: {
+  skipAutoConnect?: boolean;
+  hasSavedToken: boolean;
+}): LynxAutoConnectPhase {
+  if (input.skipAutoConnect || !input.hasSavedToken) return 'done';
+  return 'pending';
+}
+
+export function shouldAttemptAutoConnect(input: {
+  skipAutoConnect?: boolean;
+  hasSavedToken: boolean;
+}): boolean {
+  return !input.skipAutoConnect && input.hasSavedToken;
+}
+
+/**
+ * Race an auto-connect attempt with a short timeout. Timeout / reject → false
+ * so the caller can always finish the phase machine → welcome UI.
+ */
+export async function raceAutoConnectAttempt(
+  attempt: Promise<boolean>,
+  timeoutMs: number = AUTO_CONNECT_ATTEMPT_TIMEOUT_MS,
+): Promise<boolean> {
+  const settled = await raceWithTimeout(
+    timeoutMs,
+    attempt.then((ok) => ok).catch(() => false),
+  );
+  return settled === true;
 }

--- a/packages/lynx/src/index.ts
+++ b/packages/lynx/src/index.ts
@@ -191,8 +191,12 @@ export {
   LYNX_TITLE_COLLAPSE_DISTANCE,
 } from './shell/tabPageHeader';
 export {
-  resolveLynxConnectGate,
+  AUTO_CONNECT_ATTEMPT_TIMEOUT_MS,
+  initialAutoConnectPhase,
   nextAutoConnectPhase,
+  raceAutoConnectAttempt,
+  resolveLynxConnectGate,
+  shouldAttemptAutoConnect,
   type LynxAutoConnectPhase,
 } from './connect/autoConnectPhase';
 export { parsePastedPairingLink } from './connect/pairingPaste';


### PR DESCRIPTION
## Summary
- **Cause:** `App.tsx` kept `ConnectWelcome` on the Connecting splash while `phase !== 'done'`. `autoConnect` awaited `client.autoConnectLastInstance()` with no bound; if the effect never settles or the probe hangs, users never reach paste / Scan QR.
- **Fix:** Start at `done` when `skipAutoConnect` or no saved connection with `hasToken` (skip splash). When attempting, `raceAutoConnectAttempt` (2.5s) so `finally` always finishes → welcome.
- Pure helpers + vitest coverage in `autoConnectPhase`; exports updated.

## Test plan
- [x] `bunx vitest run src/connect/autoConnectPhase.test.ts` (packages/lynx)
- [x] `bun run test` in packages/lynx (523 passed)
- [x] `bun run type-check` in packages/lynx
- [ ] Sideload tip APK: cold start with empty stores → Connect welcome (paste / Scan QR), not infinite Connecting…

Base: `work/lynx-native` (never main).